### PR TITLE
Flash Messages template is not preselected when creating a new entry.

### DIFF
--- a/application-flashmessages-ui/src/main/resources/Flash/Code/FlashMessagesTemplateProvider.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/Code/FlashMessagesTemplateProvider.xml
@@ -247,7 +247,9 @@
       <name>templateProvider.flashmessages.name</name>
     </property>
     <property>
-      <spaces/>
+      <spaces>
+        <value>Flash</value>
+      </spaces>
     </property>
     <property>
       <template>Flash.FlashTemplate</template>


### PR DESCRIPTION
Issue: https://github.com/xwikisas/application-flashmessages/issues/13

Now the template will appear only in the Flash space(it is also preselected).