### PR TITLE
Issue#26: The 'Groups' drop-down filter box should display only groups added on entries (instead of all existing groups on the wiki) 

### DIFF
--- a/application-flashmessages-ui/src/main/resources/Flash/WebHomeSheet.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/WebHomeSheet.xml
@@ -81,6 +81,15 @@
     'tagCloud': true,
     'selectedColumn': 'doc.title'
   })
+  ## Checking if groups type (list) can be replaced with suggest (supported in 9.8 &amp; earlier)
+  ## In the futere, when upgrading to a version earlier than 9.8, should definetelly change it to suggest
+  #set ($actualVersion = $services.extension.core.repository.environmentExtension.id.version.value)
+  #set ($actualVersion = $mathtool.toDouble($actualVersion))
+  #set ($minimalVersion = 9.8)
+  ## Change groups type with suggest
+  #if ($actualVersion &gt;= $minimalVersion)
+    #set($columnsProperties.groups.type = 'suggest')
+  #end
   ##
   #livetable('flash' $columns $columnsProperties $options)
 #end

--- a/application-flashmessages-ui/src/main/resources/Flash/WebHomeSheet.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/WebHomeSheet.xml
@@ -83,12 +83,8 @@
   })
   ## Checking if groups type (list) can be replaced with suggest (supported in 9.8 &amp; earlier)
   ## In the futere, when upgrading to a version earlier than 9.8, should definetelly change it to suggest
-  #set ($actualVersion = $services.extension.core.repository.environmentExtension.id.version.value)
-  #set ($actualVersion = $mathtool.toDouble($actualVersion))
-  #set ($minimalVersion = 9.8)
-  ## Change groups type with suggest
-  #if ($actualVersion &gt;= $minimalVersion)
-    #set($columnsProperties.groups.type = 'suggest')
+  #if ('#livetable_filters' != "#livetable_filters")
+    #set ($columnsProperties.groups.type = 'suggest')
   #end
   ##
   #livetable('flash' $columns $columnsProperties $options)


### PR DESCRIPTION
In newer versions (>=9.8), groups column can be made `suggest` instead of using `list`. 
After upgrading to a newer version (for existing support), `list` can be replaced definitely with `suggest`.