### PR TITLE
Flash Messages Application's recurrency not working #10

### DIFF
--- a/application-flashmessages-ui/src/main/resources/Flash/DisplayFlashMessages.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/DisplayFlashMessages.xml
@@ -155,7 +155,8 @@
   #set ($wasSeenToday = $datetool.format($dateFormat, $dateNow) == $datetool.format($dateFormat, $seenDate))
   #set ($doRepeatEntry = $msgDoc.getObject('Flash.FlashClass').getValue('repeat') == 1)
   ## Check if the message was already seen by this user or if it wasn't seen today, for entries with repeat selected.
-  #if ((!$userValList.contains($msg.doc) &amp;&amp; !$msgValList.contains($xcontext.user)) || (!$wasSeenToday &amp;&amp; $doRepeatEntry))
+  #if ((!$userValList.contains($msg.doc) &amp;&amp; !$msgValList.contains($xcontext.user))
+      || (!$wasSeenToday &amp;&amp; $doRepeatEntry))
     #set ($discard = $need.add($msg.doc))
   #end
 #end

--- a/application-flashmessages-ui/src/main/resources/Flash/DisplayFlashMessages.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/DisplayFlashMessages.xml
@@ -42,10 +42,6 @@
   <content>{{include reference="Flash.Macros"/}}
 
 {{velocity}}
-###############################################
-##           LOAD POPUP MANAGER
-###############################################
-#set($discard = $xwiki.jsx.use('Flash.FlashNotifier', {'minify':false}))
 ##
 ###############################################
 ##           LOAD MESSAGE SLIDER
@@ -86,6 +82,7 @@
 ##            DISPLAY MESSAGES
 ###############################################
 #set($dateNow = $datetool.getSystemDate())
+#set($dateFormat = $xwiki.getXWikiPreference('dateformat', 'dd/MM/yyyy'))
 ##
 ## If the user is not in any group then no message should be displayed
 #if("$!groupsFilter" != '')
@@ -150,13 +147,16 @@
 #set($userValObj = $userDoc.getObject('Flash.FlashValidationClass'))
 #set($userValList = $userValObj.getProperty('flash').getValue())
 #set($need = [])
-#foreach($msg in $events)
-  #set($msgDoc = $xwiki.getDocument($msg.doc))
-  #set($msgValObj = $msgDoc.getObject('Flash.FlashValidationClass'))
-  #set($msgValList = $msgValObj.getProperty('flash').getValue())
-  ##
-  #if(!$userValList.contains($msg.doc) &amp;&amp; !$msgValList.contains($xcontext.user))
-    #set($discard = $need.add($msg.doc))
+#foreach ($msg in $events)
+  #set ($msgDoc = $xwiki.getDocument($msg.doc))
+  #set ($msgValObj = $msgDoc.getObject('Flash.FlashValidationClass'))
+  #set ($msgValList = $msgValObj.getProperty('flash').getValue())
+  #set ($seenDate = $msgValObj.getValue('seenDate'))
+  #set ($wasSeenToday = $datetool.format($dateFormat, $dateNow) == $datetool.format($dateFormat, $seenDate))
+  #set ($doRepeatEntry = $msgDoc.getObject('Flash.FlashClass').getValue('repeat') == 1)
+  ## Check if the message was already seen by this user or if it wasn't seen today, for entries with repeat selected.
+  #if ((!$userValList.contains($msg.doc) &amp;&amp; !$msgValList.contains($xcontext.user)) || (!$wasSeenToday &amp;&amp; $doRepeatEntry))
+    #set ($discard = $need.add($msg.doc))
   #end
 #end
 #if(!$need.empty())
@@ -181,9 +181,14 @@
     }
   #end
     ];
-    require(['jquery'], function($) {
-      window.flashNotifier(params);
+    require.config({
+      'paths': {
+         'flashNotifier': new XWiki.Document('FlashNotifier', 'Flash').getURL('jsx', 'r=1')
+       }
+    });
+    require(['jquery', 'flashNotifier', 'bootstrap'], function($) {
       window.flashPopup = $('#flashPopup');
+      window.flashNotifier(params);
     });
   });
   &lt;/script&gt;

--- a/application-flashmessages-ui/src/main/resources/Flash/DisplayFlashMessages.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/DisplayFlashMessages.xml
@@ -82,7 +82,6 @@
 ##            DISPLAY MESSAGES
 ###############################################
 #set($dateNow = $datetool.getSystemDate())
-#set($dateFormat = $xwiki.getXWikiPreference('dateformat', 'dd/MM/yyyy'))
 ##
 ## If the user is not in any group then no message should be displayed
 #if("$!groupsFilter" != '')
@@ -147,6 +146,7 @@
 #set($userValObj = $userDoc.getObject('Flash.FlashValidationClass'))
 #set($userValList = $userValObj.getProperty('flash').getValue())
 #set($need = [])
+#set($dateFormat = 'dd/MM/yyyy')
 #foreach ($msg in $events)
   #set ($msgDoc = $xwiki.getDocument($msg.doc))
   #set ($msgValObj = $msgDoc.getObject('Flash.FlashValidationClass'))

--- a/application-flashmessages-ui/src/main/resources/Flash/FlashNotifier.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/FlashNotifier.xml
@@ -42,11 +42,10 @@
   <content>{{velocity}}
 ## Mark the message as seen by the current user
 #if("$!request.ajax" == '1' &amp;&amp; $xcontext.action == 'get')
-  #set($dateNow = $datetool.getSystemDate())
+  #set($dateNow = $datetool.date)
   #set($msgdoc = $xwiki.getDocument($request.flash))
   #set($userdoc = $xwiki.getDocument($xcontext.user))
   #if($userdoc &amp;&amp; !$userdoc.isNew() &amp;&amp; $xwiki.exists($msgdoc))
-    #set($dateFormat = $xwiki.getXWikiPreference('dateformat', 'dd/MM/yyyy'))
     ## Start by looking in the user document in order to ensure backwards compatibility
     #set($obj = $userdoc.getObject('Flash.FlashValidationClass'))
     #set($list = $obj.getProperty('flash').getValue())
@@ -67,6 +66,7 @@
       #end
     #end
     ## Check if the message should be marked as seen today.
+    #set($dateFormat = 'dd/MM/yyyy')
     #set ($msgObj = $msgdoc.getObject('Flash.FlashValidationClass'))
     #set ($seenDate = $msgObj.getValue('seenDate'))
     #set ($wasSeenToday = $datetool.format($dateFormat, $dateNow) == $datetool.format($dateFormat, $seenDate))
@@ -185,9 +185,7 @@
       window.flashPopup.modal('show');
     } else {
       // Show the popup.
-      $(window).on('load', function() {
-        window.flashPopup.modal('show');
-      });
+      $($.proxy(window.flashPopup, 'modal', 'show'));
     }
   }
   /**
@@ -237,6 +235,45 @@
     </property>
     <property>
       <use>onDemand</use>
+    </property>
+  </object>
+  <object>
+    <name>Flash.FlashNotifier</name>
+    <number>0</number>
+    <className>XWiki.RequiredRightClass</className>
+    <guid>fc65af4c-2fa1-466e-9393-6264836d608b</guid>
+    <class>
+      <name>XWiki.RequiredRightClass</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <level>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>0</multiSelect>
+        <name>level</name>
+        <number>1</number>
+        <picker>0</picker>
+        <prettyName>level</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators> ,|</separators>
+        <size>1</size>
+        <sort>none</sort>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <values>edit|programming</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </level>
+    </class>
+    <property>
+      <level>programming</level>
     </property>
   </object>
   <object>

--- a/application-flashmessages-ui/src/main/resources/Flash/FlashNotifier.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/FlashNotifier.xml
@@ -42,9 +42,11 @@
   <content>{{velocity}}
 ## Mark the message as seen by the current user
 #if("$!request.ajax" == '1' &amp;&amp; $xcontext.action == 'get')
+  #set($dateNow = $datetool.getSystemDate())
   #set($msgdoc = $xwiki.getDocument($request.flash))
   #set($userdoc = $xwiki.getDocument($xcontext.user))
   #if($userdoc &amp;&amp; !$userdoc.isNew() &amp;&amp; $xwiki.exists($msgdoc))
+    #set($dateFormat = $xwiki.getXWikiPreference('dateformat', 'dd/MM/yyyy'))
     ## Start by looking in the user document in order to ensure backwards compatibility
     #set($obj = $userdoc.getObject('Flash.FlashValidationClass'))
     #set($list = $obj.getProperty('flash').getValue())
@@ -59,12 +61,18 @@
       #set($list = $obj.getProperty('flash').getValue())
       #if($list == $util.getNull())
         #set($discard = $obj.set('flash', [$xcontext.user]))
-        #set($discard = $msgdoc.saveAsAuthor("$xcontext.user has seen the message"))
       #elseif($list.class.name == 'com.xpn.xwiki.objects.ListProperty$NotifyList' &amp;&amp; !$list.contains($xcontext.user))
         #set($discard = $list.add($xcontext.user))
         #set($discard = $obj.set('flash', $list))
-        #set($discard = $msgdoc.saveAsAuthor("$xcontext.user has seen the message"))
       #end
+    #end
+    ## Check if the message should be marked as seen today.
+    #set ($msgObj = $msgdoc.getObject('Flash.FlashValidationClass'))
+    #set ($seenDate = $msgObj.getValue('seenDate'))
+    #set ($wasSeenToday = $datetool.format($dateFormat, $dateNow) == $datetool.format($dateFormat, $seenDate))
+    #if (!$seen || !$wasSeenToday)
+      #set ($discard = $msgObj.set('seenDate', $dateNow))
+      #set ($discard = $msgdoc.saveAsAuthor("$xcontext.user has seen the message"))
     #end
   #end
 #end
@@ -153,7 +161,7 @@
       <cache>long</cache>
     </property>
     <property>
-      <code>require(['jquery'], function($) {
+      <code>define('flashNotifier', ['jquery'], function($) {
   /**
    * Initialize the flash notifier.
    */
@@ -172,13 +180,14 @@
     }
     // Get the params.
     var params = window.flashNotifierParams[window.flashNotifierIndex];
-    // Show the popup.
-    $(window).on('load', function() {
-      window.flashPopup.modal('show');
-    });
     // When window has already been loaded.
-    if(window.flashNotifierIndex &gt; 0) {
+    if(document.readyState === 'complete') {
       window.flashPopup.modal('show');
+    } else {
+      // Show the popup.
+      $(window).on('load', function() {
+        window.flashPopup.modal('show');
+      });
     }
   }
   /**
@@ -189,7 +198,7 @@
     url = new XWiki.Document('FlashNotifier', 'Flash').getURL('get');
     $.ajax({
       url : url,
-      data : {'ajax' : '1', 'flash' : params['document']},
+      data : {'ajax' : '1', 'flash' : params['document']}
     });
     window.flashNotifierIndex++;
     window.flashNotifierNext();

--- a/application-flashmessages-ui/src/main/resources/Flash/FlashValidationClass.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/FlashValidationClass.xml
@@ -73,6 +73,21 @@
       <valueField>doc.fullName</valueField>
       <classType>com.xpn.xwiki.objects.classes.DBListClass</classType>
     </flash>
+    <seenDate>
+      <customDisplay/>
+      <dateFormat>dd/MM/yyyy HH:mm:ss</dateFormat>
+      <disabled>0</disabled>
+      <emptyIsToday>1</emptyIsToday>
+      <name>seenDate</name>
+      <number>2</number>
+      <picker>1</picker>
+      <prettyName>seenDate</prettyName>
+      <size>20</size>
+      <unmodifiable>0</unmodifiable>
+      <validationMessage/>
+      <validationRegExp/>
+      <classType>com.xpn.xwiki.objects.classes.DateClass</classType>
+    </seenDate>
   </class>
   <object>
     <name>Flash.FlashValidationClass</name>


### PR DESCRIPTION
* added the date when the message was last seen in FlashValidationClass and compare this with the current date, only for entries that have 'repeat' activated.

* initial commits on https://github.com/xwikisas/application-flashmessages/pull/25 that will be postponed since it includes changes for docker testing that cannot be commited to master yet 