### PR TITLE
The 'groups' column filter (select input) causes a Java Heap error in wikis with large amounts of groups #49

### DIFF
--- a/application-flashmessages-ui/src/main/resources/Flash/WebHomeSheet.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/WebHomeSheet.xml
@@ -72,7 +72,7 @@
     'dateEnd': {'type': 'text', 'size': 10},
     'message': {'type': 'text', 'size': 10, 'sortable': false, 'html': true},
     'doc.date': {'type': 'text', 'link': 'view', 'size': 10},
-    'groups': {'type': 'list', 'size': 10, 'html': true},
+    'groups': {'type': 'suggest', 'size': 10, 'html': true},
     '_actions': {'html': true, 'sortable': false, 'filterable': false, 'actions': ['edit', 'delete']}
   })
   #set($options = {


### PR DESCRIPTION
*changed groups column type from `list` to `suggest`