### PR TITLE
Allow farm-wide messages to be set from a flash messages application installed on the main wiki #68

### DIFF
--- a/application-flashmessages-test/application-flashmessages-test-docker/pom.xml
+++ b/application-flashmessages-test/application-flashmessages-test-docker/pom.xml
@@ -62,6 +62,12 @@
       <version>${platform.version}</version>
       <type>xar</type>
     </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-search-solr-test-utils</artifactId>
+      <version>${platform.version}</version>
+      <scope>test</scope>
+    </dependency>
 
     <!--When the licensing app has 14.10 as parent remove the content below -->
     <dependency>

--- a/application-flashmessages-test/application-flashmessages-test-docker/src/test/it/org/xwiki/flashmessages/test/ui/FlashEntry.java
+++ b/application-flashmessages-test/application-flashmessages-test-docker/src/test/it/org/xwiki/flashmessages/test/ui/FlashEntry.java
@@ -46,7 +46,7 @@ public class FlashEntry
 
     private ArrayList<String> groups;
 
-    private String subwikis;
+    private String wikiScope;
 
     private String message;
 
@@ -61,11 +61,11 @@ public class FlashEntry
      * @param repeatFrequency the repeat frequency
      * @param repeatDays the repeat days
      * @param groups the xwiki groups
-     * @param subwikis the subwikis the message will appear in
+     * @param wikiScope the wiki scope where the message should be visible (currentWiki|allWikis)
      * @param message the display message
      */
     public FlashEntry(String name, Calendar dateBegin, Calendar dateEnd, Boolean repeat, String repeatInterval,
-        int repeatFrequency, ArrayList<String> repeatDays, ArrayList<String> groups, String subwikis,
+        int repeatFrequency, ArrayList<String> repeatDays, ArrayList<String> groups, String wikiScope,
         String message)
     {
         this.name = name;
@@ -76,7 +76,7 @@ public class FlashEntry
         this.repeatFrequency = repeatFrequency;
         this.repeatDays = repeatDays;
         this.groups = groups;
-        this.subwikis = subwikis;
+        this.wikiScope = wikiScope;
         this.message = message;
     }
 
@@ -241,23 +241,23 @@ public class FlashEntry
     }
 
     /**
-     * Get subwikis
+     * Get wikiScope
      *
-     * @return the list of subwikis towards the entry is aimed
+     * @return the wiki scope where the message should be visible (currentWiki|allWikis)
      */
-    public String getSubwikis()
+    public String getWikiScope()
     {
-        return subwikis;
+        return wikiScope;
     }
 
     /**
-     * Set subwikis
+     * Set wikiScope
      *
-     * @param subwikis the list of subwikis towards the entry is aimed
+     * @param wikiScope the wiki scope where the message should be visible (currentWiki|allWikis)
      */
-    public void setSubwikis(String subwikis)
+    public void setWikiScope(String wikiScope)
     {
-        this.subwikis = subwikis;
+        this.wikiScope = wikiScope;
     }
 
     /**

--- a/application-flashmessages-test/application-flashmessages-test-docker/src/test/it/org/xwiki/flashmessages/test/ui/FlashEntry.java
+++ b/application-flashmessages-test/application-flashmessages-test-docker/src/test/it/org/xwiki/flashmessages/test/ui/FlashEntry.java
@@ -46,6 +46,8 @@ public class FlashEntry
 
     private ArrayList<String> groups;
 
+    private ArrayList<String> subwikis;
+
     private String message;
 
     /**
@@ -59,10 +61,12 @@ public class FlashEntry
      * @param repeatFrequency the repeat frequency
      * @param repeatDays the repeat days
      * @param groups the xwiki groups
+     * @param subwikis the subwikis the message will appear in
      * @param message the display message
      */
     public FlashEntry(String name, Calendar dateBegin, Calendar dateEnd, Boolean repeat, String repeatInterval,
-        int repeatFrequency, ArrayList<String> repeatDays, ArrayList<String> groups, String message)
+        int repeatFrequency, ArrayList<String> repeatDays, ArrayList<String> groups, ArrayList<String> subwikis,
+        String message)
     {
         this.name = name;
         this.dateBegin = dateBegin;
@@ -72,6 +76,7 @@ public class FlashEntry
         this.repeatFrequency = repeatFrequency;
         this.repeatDays = repeatDays;
         this.groups = groups;
+        this.subwikis = subwikis;
         this.message = message;
     }
 
@@ -233,6 +238,26 @@ public class FlashEntry
     public void setGroups(ArrayList<String> groups)
     {
         this.groups = groups;
+    }
+
+    /**
+     * Get subwikis
+     *
+     * @return the list of subwikis towards the entry is aimed
+     */
+    public ArrayList<String> getSubwikis()
+    {
+        return subwikis;
+    }
+
+    /**
+     * Set subwikis
+     *
+     * @param subwikis the list of subwikis towards the entry is aimed
+     */
+    public void setSubwikis(ArrayList<String> subwikis)
+    {
+        this.subwikis = subwikis;
     }
 
     /**

--- a/application-flashmessages-test/application-flashmessages-test-docker/src/test/it/org/xwiki/flashmessages/test/ui/FlashEntry.java
+++ b/application-flashmessages-test/application-flashmessages-test-docker/src/test/it/org/xwiki/flashmessages/test/ui/FlashEntry.java
@@ -46,7 +46,7 @@ public class FlashEntry
 
     private ArrayList<String> groups;
 
-    private ArrayList<String> subwikis;
+    private String subwikis;
 
     private String message;
 
@@ -65,7 +65,7 @@ public class FlashEntry
      * @param message the display message
      */
     public FlashEntry(String name, Calendar dateBegin, Calendar dateEnd, Boolean repeat, String repeatInterval,
-        int repeatFrequency, ArrayList<String> repeatDays, ArrayList<String> groups, ArrayList<String> subwikis,
+        int repeatFrequency, ArrayList<String> repeatDays, ArrayList<String> groups, String subwikis,
         String message)
     {
         this.name = name;
@@ -245,7 +245,7 @@ public class FlashEntry
      *
      * @return the list of subwikis towards the entry is aimed
      */
-    public ArrayList<String> getSubwikis()
+    public String getSubwikis()
     {
         return subwikis;
     }
@@ -255,7 +255,7 @@ public class FlashEntry
      *
      * @param subwikis the list of subwikis towards the entry is aimed
      */
-    public void setSubwikis(ArrayList<String> subwikis)
+    public void setSubwikis(String subwikis)
     {
         this.subwikis = subwikis;
     }

--- a/application-flashmessages-test/application-flashmessages-test-docker/src/test/it/org/xwiki/flashmessages/test/ui/FlashIT.java
+++ b/application-flashmessages-test/application-flashmessages-test-docker/src/test/it/org/xwiki/flashmessages/test/ui/FlashIT.java
@@ -66,7 +66,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
         )
     },
     extraJARs = {
-        "org.bouncycastle:bcprov-jdk15on:jar:1.64"
+        "org.bouncycastle:bcprov-jdk15on:jar:1.64",
+        // The Solr store is not ready yet to be installed as extension
+        "org.xwiki.platform:xwiki-platform-eventstream-store-solr:14.10",
+        "org.xwiki.platform:xwiki-platform-search-solr-query:14.10"
     }
 )
 class FlashIT
@@ -127,6 +130,7 @@ class FlashIT
                 2,
                 new ArrayList<String>(Arrays.asList(flashUtil.getCurrentDayOfTheWeek())),
                 new ArrayList<String>(Arrays.asList("XWikiAllGroup")),
+                new ArrayList<String>(Arrays.asList("xwiki")),
                 "Hi! It is like hello, only shorter.");
             flashUtil.setDefaultEntry(defaultEntry);
         }
@@ -138,6 +142,9 @@ class FlashIT
 
             // Create the document
             flashUtil.createEntry(flashUtil.getDefaultEntry());
+
+            // Wait for flashmessage to be registered with solr.
+            flashUtil.waitUntilSolrReindex();
 
             // Go to the entry view page
             FlashEntryViewPage entryViewPage = flashUtil.getDefaultEntryViewPage();
@@ -382,6 +389,7 @@ class FlashIT
             1,
             new ArrayList<String>(),
             new ArrayList<String>(Arrays.asList("XWikiAllGroup")),
+            new ArrayList<String>(Arrays.asList("xwiki")),
             "Daily");
 
         // Create test message and close the 1st time pop-up
@@ -406,6 +414,7 @@ class FlashIT
             1,
             new ArrayList<String>(),
             new ArrayList<String>(Arrays.asList("XWikiAdminGroup")),
+            new ArrayList<String>(Arrays.asList("xwiki")),
             "NonRecurringActiveMessage");
 
         flashUtil.testMessage(entry, true);
@@ -422,6 +431,7 @@ class FlashIT
             1,
             new ArrayList<String>(),
             new ArrayList<String>(Arrays.asList("XWikiAdminGroup")),
+            new ArrayList<String>(Arrays.asList("xwiki")),
             "NonRecurringInactiveMessage");
 
         flashUtil.testMessage(entry, false);
@@ -438,6 +448,7 @@ class FlashIT
             2,
             new ArrayList<String>(),
             new ArrayList<String>(Arrays.asList("XWikiAdminGroup")),
+            new ArrayList<String>(Arrays.asList("xwiki")),
             "Every 2 days");
 
         flashUtil.testMessage(entry, true);
@@ -454,6 +465,7 @@ class FlashIT
             5,
             new ArrayList<String>(),
             new ArrayList<String>(Arrays.asList("XWikiAdminGroup")),
+            new ArrayList<String>(Arrays.asList("xwiki")),
             "Every 3 days");
 
         flashUtil.testMessage(entry, false);
@@ -470,6 +482,7 @@ class FlashIT
             2,
             new ArrayList<String>(Arrays.asList(flashUtil.getCurrentDayOfTheWeek())),
             new ArrayList<String>(Arrays.asList("XWikiAllGroup")),
+            new ArrayList<String>(Arrays.asList("xwiki")),
             "Every 2 weeks");
 
         flashUtil.testMessage(entry, true);
@@ -486,6 +499,7 @@ class FlashIT
             2,
             new ArrayList<String>(Arrays.asList(flashUtil.getCurrentDayOfTheWeek() == "monday" ? "tuesday" : "monday")),
             new ArrayList<String>(Arrays.asList("XWikiAllGroup")),
+            new ArrayList<String>(Arrays.asList("xwiki")),
             "Every 2 weeks");
 
         flashUtil.testMessage(entry, false);
@@ -502,6 +516,7 @@ class FlashIT
             6,
             new ArrayList<String>(),
             new ArrayList<String>(Arrays.asList("XWikiAllGroup")),
+            new ArrayList<String>(Arrays.asList("xwiki")),
             "Every 6 months");
 
         flashUtil.testMessage(entry, true);
@@ -518,6 +533,7 @@ class FlashIT
             9,
             new ArrayList<String>(),
             new ArrayList<String>(Arrays.asList("XWikiAllGroup")),
+            new ArrayList<String>(Arrays.asList("xwiki")),
             "Every 9 months");
 
         flashUtil.testMessage(entry, false);
@@ -534,6 +550,7 @@ class FlashIT
             2,
             new ArrayList<String>(),
             new ArrayList<String>(Arrays.asList("XWikiAllGroup")),
+            new ArrayList<String>(Arrays.asList("xwiki")),
             "Every 2 years today");
 
         flashUtil.testMessage(entry, true);
@@ -550,6 +567,7 @@ class FlashIT
             3,
             new ArrayList<String>(),
             new ArrayList<String>(Arrays.asList("XWikiAllGroup")),
+            new ArrayList<String>(Arrays.asList("xwiki")),
             "Every 3 years today");
 
         flashUtil.testMessage(entry, false);

--- a/application-flashmessages-test/application-flashmessages-test-docker/src/test/it/org/xwiki/flashmessages/test/ui/FlashIT.java
+++ b/application-flashmessages-test/application-flashmessages-test-docker/src/test/it/org/xwiki/flashmessages/test/ui/FlashIT.java
@@ -130,7 +130,7 @@ class FlashIT
                 2,
                 new ArrayList<String>(Arrays.asList(flashUtil.getCurrentDayOfTheWeek())),
                 new ArrayList<String>(Arrays.asList("XWikiAllGroup")),
-                new ArrayList<String>(Arrays.asList("xwiki")),
+                "current",
                 "Hi! It is like hello, only shorter.");
             flashUtil.setDefaultEntry(defaultEntry);
         }
@@ -389,7 +389,7 @@ class FlashIT
             1,
             new ArrayList<String>(),
             new ArrayList<String>(Arrays.asList("XWikiAllGroup")),
-            new ArrayList<String>(Arrays.asList("xwiki")),
+            "current",
             "Daily");
 
         // Create test message and close the 1st time pop-up
@@ -414,7 +414,7 @@ class FlashIT
             1,
             new ArrayList<String>(),
             new ArrayList<String>(Arrays.asList("XWikiAdminGroup")),
-            new ArrayList<String>(Arrays.asList("xwiki")),
+            "current",
             "NonRecurringActiveMessage");
 
         flashUtil.testMessage(entry, true);
@@ -431,7 +431,7 @@ class FlashIT
             1,
             new ArrayList<String>(),
             new ArrayList<String>(Arrays.asList("XWikiAdminGroup")),
-            new ArrayList<String>(Arrays.asList("xwiki")),
+            "current",
             "NonRecurringInactiveMessage");
 
         flashUtil.testMessage(entry, false);
@@ -448,7 +448,7 @@ class FlashIT
             2,
             new ArrayList<String>(),
             new ArrayList<String>(Arrays.asList("XWikiAdminGroup")),
-            new ArrayList<String>(Arrays.asList("xwiki")),
+            "current",
             "Every 2 days");
 
         flashUtil.testMessage(entry, true);
@@ -465,7 +465,7 @@ class FlashIT
             5,
             new ArrayList<String>(),
             new ArrayList<String>(Arrays.asList("XWikiAdminGroup")),
-            new ArrayList<String>(Arrays.asList("xwiki")),
+            "current",
             "Every 3 days");
 
         flashUtil.testMessage(entry, false);
@@ -482,7 +482,7 @@ class FlashIT
             2,
             new ArrayList<String>(Arrays.asList(flashUtil.getCurrentDayOfTheWeek())),
             new ArrayList<String>(Arrays.asList("XWikiAllGroup")),
-            new ArrayList<String>(Arrays.asList("xwiki")),
+            "current",
             "Every 2 weeks");
 
         flashUtil.testMessage(entry, true);
@@ -499,7 +499,7 @@ class FlashIT
             2,
             new ArrayList<String>(Arrays.asList(flashUtil.getCurrentDayOfTheWeek() == "monday" ? "tuesday" : "monday")),
             new ArrayList<String>(Arrays.asList("XWikiAllGroup")),
-            new ArrayList<String>(Arrays.asList("xwiki")),
+            "current",
             "Every 2 weeks");
 
         flashUtil.testMessage(entry, false);
@@ -516,7 +516,7 @@ class FlashIT
             6,
             new ArrayList<String>(),
             new ArrayList<String>(Arrays.asList("XWikiAllGroup")),
-            new ArrayList<String>(Arrays.asList("xwiki")),
+            "current",
             "Every 6 months");
 
         flashUtil.testMessage(entry, true);
@@ -533,7 +533,7 @@ class FlashIT
             9,
             new ArrayList<String>(),
             new ArrayList<String>(Arrays.asList("XWikiAllGroup")),
-            new ArrayList<String>(Arrays.asList("xwiki")),
+            "current",
             "Every 9 months");
 
         flashUtil.testMessage(entry, false);
@@ -550,7 +550,7 @@ class FlashIT
             2,
             new ArrayList<String>(),
             new ArrayList<String>(Arrays.asList("XWikiAllGroup")),
-            new ArrayList<String>(Arrays.asList("xwiki")),
+            "current",
             "Every 2 years today");
 
         flashUtil.testMessage(entry, true);
@@ -567,7 +567,7 @@ class FlashIT
             3,
             new ArrayList<String>(),
             new ArrayList<String>(Arrays.asList("XWikiAllGroup")),
-            new ArrayList<String>(Arrays.asList("xwiki")),
+            "current",
             "Every 3 years today");
 
         flashUtil.testMessage(entry, false);

--- a/application-flashmessages-test/application-flashmessages-test-docker/src/test/it/org/xwiki/flashmessages/test/ui/FlashIT.java
+++ b/application-flashmessages-test/application-flashmessages-test-docker/src/test/it/org/xwiki/flashmessages/test/ui/FlashIT.java
@@ -130,7 +130,7 @@ class FlashIT
                 2,
                 new ArrayList<String>(Arrays.asList(flashUtil.getCurrentDayOfTheWeek())),
                 new ArrayList<String>(Arrays.asList("XWikiAllGroup")),
-                "current",
+                "currentWiki",
                 "Hi! It is like hello, only shorter.");
             flashUtil.setDefaultEntry(defaultEntry);
         }
@@ -389,7 +389,7 @@ class FlashIT
             1,
             new ArrayList<String>(),
             new ArrayList<String>(Arrays.asList("XWikiAllGroup")),
-            "current",
+            "currentWiki",
             "Daily");
 
         // Create test message and close the 1st time pop-up
@@ -414,7 +414,7 @@ class FlashIT
             1,
             new ArrayList<String>(),
             new ArrayList<String>(Arrays.asList("XWikiAdminGroup")),
-            "current",
+            "currentWiki",
             "NonRecurringActiveMessage");
 
         flashUtil.testMessage(entry, true);
@@ -431,7 +431,7 @@ class FlashIT
             1,
             new ArrayList<String>(),
             new ArrayList<String>(Arrays.asList("XWikiAdminGroup")),
-            "current",
+            "currentWiki",
             "NonRecurringInactiveMessage");
 
         flashUtil.testMessage(entry, false);
@@ -448,7 +448,7 @@ class FlashIT
             2,
             new ArrayList<String>(),
             new ArrayList<String>(Arrays.asList("XWikiAdminGroup")),
-            "current",
+            "currentWiki",
             "Every 2 days");
 
         flashUtil.testMessage(entry, true);
@@ -465,7 +465,7 @@ class FlashIT
             5,
             new ArrayList<String>(),
             new ArrayList<String>(Arrays.asList("XWikiAdminGroup")),
-            "current",
+            "currentWiki",
             "Every 3 days");
 
         flashUtil.testMessage(entry, false);
@@ -482,7 +482,7 @@ class FlashIT
             2,
             new ArrayList<String>(Arrays.asList(flashUtil.getCurrentDayOfTheWeek())),
             new ArrayList<String>(Arrays.asList("XWikiAllGroup")),
-            "current",
+            "currentWiki",
             "Every 2 weeks");
 
         flashUtil.testMessage(entry, true);
@@ -499,7 +499,7 @@ class FlashIT
             2,
             new ArrayList<String>(Arrays.asList(flashUtil.getCurrentDayOfTheWeek() == "monday" ? "tuesday" : "monday")),
             new ArrayList<String>(Arrays.asList("XWikiAllGroup")),
-            "current",
+            "currentWiki",
             "Every 2 weeks");
 
         flashUtil.testMessage(entry, false);
@@ -516,7 +516,7 @@ class FlashIT
             6,
             new ArrayList<String>(),
             new ArrayList<String>(Arrays.asList("XWikiAllGroup")),
-            "current",
+            "currentWiki",
             "Every 6 months");
 
         flashUtil.testMessage(entry, true);
@@ -533,7 +533,7 @@ class FlashIT
             9,
             new ArrayList<String>(),
             new ArrayList<String>(Arrays.asList("XWikiAllGroup")),
-            "current",
+            "currentWiki",
             "Every 9 months");
 
         flashUtil.testMessage(entry, false);
@@ -550,7 +550,7 @@ class FlashIT
             2,
             new ArrayList<String>(),
             new ArrayList<String>(Arrays.asList("XWikiAllGroup")),
-            "current",
+            "currentWiki",
             "Every 2 years today");
 
         flashUtil.testMessage(entry, true);
@@ -567,7 +567,7 @@ class FlashIT
             3,
             new ArrayList<String>(),
             new ArrayList<String>(Arrays.asList("XWikiAllGroup")),
-            "current",
+            "currentWiki",
             "Every 3 years today");
 
         flashUtil.testMessage(entry, false);

--- a/application-flashmessages-test/application-flashmessages-test-docker/src/test/it/org/xwiki/flashmessages/test/ui/FlashUtil.java
+++ b/application-flashmessages-test/application-flashmessages-test-docker/src/test/it/org/xwiki/flashmessages/test/ui/FlashUtil.java
@@ -207,7 +207,7 @@ public class FlashUtil
         }
 
         entryEditPage.setGroups(entry.getGroups());
-        entryEditPage.setSubwikis(entry.getSubwikis());
+        entryEditPage.setWikiScope(entry.getWikiScope());
         entryEditPage.setMessage(entry.getMessage());
 
         return entryEditPage.clickSaveAndView();

--- a/application-flashmessages-test/application-flashmessages-test-docker/src/test/it/org/xwiki/flashmessages/test/ui/FlashUtil.java
+++ b/application-flashmessages-test/application-flashmessages-test-docker/src/test/it/org/xwiki/flashmessages/test/ui/FlashUtil.java
@@ -30,6 +30,7 @@ import org.xwiki.flashmessages.test.po.FlashEntryEditPage;
 import org.xwiki.flashmessages.test.po.FlashEntryViewPage;
 import org.xwiki.flashmessages.test.po.FlashHomePage;
 import org.xwiki.flashmessages.test.po.FlashSlider;
+import org.xwiki.repository.test.SolrTestUtils;
 import org.xwiki.test.ui.TestUtils;
 import org.xwiki.test.ui.po.CreatePagePage;
 
@@ -206,6 +207,7 @@ public class FlashUtil
         }
 
         entryEditPage.setGroups(entry.getGroups());
+        entryEditPage.setSubwikis(entry.getSubwikis());
         entryEditPage.setMessage(entry.getMessage());
 
         return entryEditPage.clickSaveAndView();
@@ -341,6 +343,9 @@ public class FlashUtil
         // Check if the entry document was created
         Assert.assertTrue(this.setup.pageExists("Flash", entry.getName()));
 
+        // Wait for flashmessage to be registered with solr.
+        waitUntilSolrReindex();
+
         // Get the Flash Message view page
         entryViewPage = FlashEntryViewPage.gotoPage(entry.getName());
 
@@ -363,5 +368,12 @@ public class FlashUtil
         }
 
         return entryViewPage;
+    }
+
+    public void waitUntilSolrReindex() throws Exception
+    {
+        System.out.println("Waiting for solr to finish indexing. This may take a while...");
+        new SolrTestUtils(setup, "http://localhost:8080/xwiki").waitEmpyQueue();
+        System.out.println("Solr indexing finished.");
     }
 }

--- a/application-flashmessages-test/application-flashmessages-test-pageobjects/src/main/java/org/xwiki/flashmessages/test/po/FlashEntryEditPage.java
+++ b/application-flashmessages-test/application-flashmessages-test-pageobjects/src/main/java/org/xwiki/flashmessages/test/po/FlashEntryEditPage.java
@@ -76,8 +76,8 @@ public class FlashEntryEditPage extends FlashPage
     @FindBy(id = "Flash.FlashClass_0_groups")
     protected WebElement groupsElement;
 
-    @FindBy(id = "Flash.FlashClass_0_subwikis")
-    protected WebElement subwikisElement;
+    @FindBy(id = "Flash.FlashClass_0_wikiScope")
+    protected WebElement wikiScopeElement;
 
     @FindBy(id = "Flash.FlashClass_0_message")
     protected WebElement messageElement;
@@ -310,14 +310,14 @@ public class FlashEntryEditPage extends FlashPage
     }
 
     /**
-     * Set the subwikis the subwikis towards the message is aimed to
+     * Set the wiki scope the message should be displayed in.
      *
-     * @param subwikis the list of subwikis for which the flashmessage is displayed
+     * @param wikiScope "currentWiki" or "allWikis"
      */
-    public void setSubwikis(String subwikis)
+    public void setWikiScope(String wikiScope)
     {
-        Select subwikisSelect = new Select(subwikisElement);
-        subwikisSelect.selectByValue(subwikis);
+        Select wikiScopeSelect = new Select(wikiScopeElement);
+        wikiScopeSelect.selectByValue(wikiScope);
     }
 
     /**

--- a/application-flashmessages-test/application-flashmessages-test-pageobjects/src/main/java/org/xwiki/flashmessages/test/po/FlashEntryEditPage.java
+++ b/application-flashmessages-test/application-flashmessages-test-pageobjects/src/main/java/org/xwiki/flashmessages/test/po/FlashEntryEditPage.java
@@ -314,14 +314,10 @@ public class FlashEntryEditPage extends FlashPage
      *
      * @param subwikis the list of subwikis for which the flashmessage is displayed
      */
-    public void setSubwikis(List<String> subwikis)
+    public void setSubwikis(String subwikis)
     {
-        SuggestInputElement subwikisSuggest = new SuggestInputElement(this.subwikisElement);
-        subwikisSuggest.clearSelectedSuggestions();
-        for (String subwiki : subwikis) {
-            subwikisSuggest.selectByValue(subwiki);
-        }
-        subwikisSuggest.hideSuggestions();
+        Select subwikisSelect = new Select(subwikisElement);
+        subwikisSelect.selectByValue(subwikis);
     }
 
     /**

--- a/application-flashmessages-test/application-flashmessages-test-pageobjects/src/main/java/org/xwiki/flashmessages/test/po/FlashEntryEditPage.java
+++ b/application-flashmessages-test/application-flashmessages-test-pageobjects/src/main/java/org/xwiki/flashmessages/test/po/FlashEntryEditPage.java
@@ -76,6 +76,9 @@ public class FlashEntryEditPage extends FlashPage
     @FindBy(id = "Flash.FlashClass_0_groups")
     protected WebElement groupsElement;
 
+    @FindBy(id = "Flash.FlashClass_0_subwikis")
+    protected WebElement subwikisElement;
+
     @FindBy(id = "Flash.FlashClass_0_message")
     protected WebElement messageElement;
 
@@ -304,6 +307,21 @@ public class FlashEntryEditPage extends FlashPage
             groupSuggest.sendKeys(group).waitForSuggestions().selectByVisibleText(group);
         }
         groupSuggest.hideSuggestions();
+    }
+
+    /**
+     * Set the subwikis the subwikis towards the message is aimed to
+     *
+     * @param subwikis the list of subwikis for which the flashmessage is displayed
+     */
+    public void setSubwikis(List<String> subwikis)
+    {
+        SuggestInputElement subwikisSuggest = new SuggestInputElement(this.subwikisElement);
+        subwikisSuggest.clearSelectedSuggestions();
+        for (String subwiki : subwikis) {
+            subwikisSuggest.selectByValue(subwiki);
+        }
+        subwikisSuggest.hideSuggestions();
     }
 
     /**

--- a/application-flashmessages-test/application-flashmessages-test-pageobjects/src/main/java/org/xwiki/flashmessages/test/po/FlashPage.java
+++ b/application-flashmessages-test/application-flashmessages-test-pageobjects/src/main/java/org/xwiki/flashmessages/test/po/FlashPage.java
@@ -43,10 +43,10 @@ public class FlashPage extends ViewPage
     @FindBy(xpath = "(//div[@class='xform']//div[@class='row'])[1]/div[2]//dt")
     protected WebElement dateEndLabelElement;
 
-    @FindBy(xpath = "(//div[@class='xform']//div[@class='row'])[2]/div[1]//dt")
+    @FindBy(xpath = "(//div[@class='xform']//div[@class='row'])[3]/div[1]//dt")
     protected WebElement repeatLabelElement;
 
-    @FindBy(xpath = "(//div[@class='xform']//div[@class='row'])[2]/div[2]//dt")
+    @FindBy(xpath = "(//div[@class='xform']//div[@class='row'])[2]/div[1]//dt")
     protected WebElement groupsLabelElement;
 
     @FindBy(xpath = "//div[@class='xform']/dl/dt")

--- a/application-flashmessages-ui/pom.xml
+++ b/application-flashmessages-ui/pom.xml
@@ -60,6 +60,18 @@
     </dependency>
     <dependency>
       <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-wiki-user-script</artifactId>
+      <version>${platform.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-wiki-user-default</artifactId>
+      <version>${platform.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
       <artifactId>xwiki-platform-rendering-macro-velocity</artifactId>
       <version>${platform.version}</version>
       <scope>runtime</scope>

--- a/application-flashmessages-ui/pom.xml
+++ b/application-flashmessages-ui/pom.xml
@@ -71,6 +71,13 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
+      <groupId>com.xwiki.commons</groupId>
+      <artifactId>xwiki-pro-commons-pickers-ui</artifactId>
+      <version>${xwikiprocommons.version}</version>
+      <type>xar</type>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>org.xwiki.platform</groupId>
       <artifactId>xwiki-platform-rendering-macro-include</artifactId>
       <version>${platform.version}</version>

--- a/application-flashmessages-ui/pom.xml
+++ b/application-flashmessages-ui/pom.xml
@@ -32,6 +32,7 @@
   <name>Flash Messages Application (Pro) - UI</name>
   <description>Schedule and display flash announcements to one or multiple groups. Messages can be set as one off or recurring events. The app can be purchased individually or part of the XWiki Pro package. Try it free.</description>
   <properties>
+    <xwikiprocommons.version>1.2.0</xwikiprocommons.version>
     <!-- Name to display by the Extension Manager -->
     <xwiki.extension.name>Flash Messages Application (Pro)</xwiki.extension.name>
     <xwiki.extension.category>application</xwiki.extension.category>

--- a/application-flashmessages-ui/src/main/resources/Flash/DisplayFlashMessages.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/DisplayFlashMessages.xml
@@ -81,7 +81,7 @@
 ##
 ## If the user is not in any group then no message should be displayed
 #if("$!groupsFilter" != '')
-  #set($baseQuery = "select doc.fullName, obj.dateBegin {0} from Document doc, doc.object(Flash.FlashClass) as obj WHERE doc.fullName &lt;&gt; 'Flash.FlashTemplate' $!groupsFilter AND obj.dateBegin &lt;= :now AND (obj.dateEnd is null OR obj.dateEnd &gt; :now) {1} ORDER BY obj.dateBegin DESC")
+  #set($baseQuery = "select doc.fullName, obj.dateBegin {0}, obj.subwikis from Document doc, doc.object(Flash.FlashClass) as obj WHERE doc.fullName &lt;&gt; 'Flash.FlashTemplate' $!groupsFilter AND obj.dateBegin &lt;= :now AND (obj.dateEnd is null OR obj.dateEnd &gt; :now) {1} ORDER BY obj.dateBegin DESC")
   ##
   #set($nonRecurringQuery = $baseQuery.replace("{0}", "").replace("{1}", "AND (obj.repeat is null OR obj.repeat = 0)"))
   #set($nonRecurring = $services.query.xwql($nonRecurringQuery).bindValue('now', $dateNow).setLimit(3).execute())
@@ -91,7 +91,10 @@
   ##
   #set($events = [])
   #foreach($event in $nonRecurring)
-    #set($discard = $events.add({'doc' : $event[0], 'date' : $event[1]}))
+    #set ($subwikis = $stringtool.split($event[2], '|'))
+    #if ($subwikis.contains($doc.getWiki()))
+      #set($discard = $events.add({'doc' : $event[0], 'date' : $event[1]}))
+    #end
   #end
   ##
   #foreach($event in $recurring)
@@ -100,17 +103,18 @@
     #set($repeatInterval  = $event[2])
     #set($repeatFrequency = $numbertool.integer($event[3]))
     #set($repeatDays      = $stringtool.split($event[4], '|'))
+    #set ($subwikis       = $stringtool.split($event[5], '|'))
     ##
     #set($today           = $datetool)
     #set($dayOfTheWeek    = $stringtool.lowerCase($datetool.format('EEEE', $today)))
     #set($dateDiff        = $datetool.difference($date, $today))
     ##
-    #if(
+    #if($subwikis.contains($doc.getWiki()) &amp;&amp; (
       ($repeatInterval == 'daily'   &amp;&amp; $mathtool.mod($dateDiff.days,   $repeatFrequency) == 0) ||
       ($repeatInterval == 'weekly'  &amp;&amp; $mathtool.mod($dateDiff.weeks,  $repeatFrequency) == 0 &amp;&amp; $repeatDays.contains($dayOfTheWeek)) ||
       ($repeatInterval == 'monthly' &amp;&amp; $mathtool.mod($dateDiff.months, $repeatFrequency) == 0 &amp;&amp; $datetool.format('d', $date) == $datetool.format('d', $today)) ||
       ($repeatInterval == 'yearly'  &amp;&amp; $mathtool.mod($dateDiff.years,  $repeatFrequency) == 0 &amp;&amp; $datetool.format('Md', $date) == $datetool.format('Md', $today))
-    )
+    ))
       #set($discard = $events.add({'doc' : $document, 'date' : $date}))
     #end
   #end

--- a/application-flashmessages-ui/src/main/resources/Flash/DisplayFlashMessages.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/DisplayFlashMessages.xml
@@ -62,6 +62,19 @@
   ## Local users are normally included only in local groups (from the same wiki).
   #set ($groups = $services.user.group.getGroupsFromMemberWiki($xcontext.userReference))
 #end
+#set ($groupsFilter = [])
+#foreach ($groupReference in $groups)
+  ## Remove the wiki component from the group reference if it matches the wiki of the message.
+  #set ($compactGroupReferenceLocal = $services.model.serialize($groupReference, 'local'))
+  #set ($compactGroupReferenceFull  = $services.model.serialize($groupReference, 'default').replace(':','\:'))
+  #set ($messageWiki = $groupReference.getWikiReference().getName())
+  #set ($discard = $groupsFilter.add("(wiki:$messageWiki AND property.Flash.FlashClass.groups:*$compactGroupReferenceLocal(,|\r)*) OR (-wiki:$messageWiki AND property.Flash.FlashClass.groups:*$compactGroupReferenceFull(,|\r)*)"))
+#end
+#if ($groupsFilter.size() &gt; 0)
+  #set ($groupsFilter = " AND ($stringtool.join($groupsFilter, ' OR ')) ")
+#else
+  #set ($groupsFilter = '')
+#end
 ##
 ###############################################
 ##            DISPLAY MESSAGES
@@ -71,58 +84,32 @@
 ## If the user is not in any group then no message should be displayed
 #if($groups.size() &gt; 0)
   #set($events = [])
-  ## Go through all subwikis which have the FlashMessages app installed.
-  #foreach ($currentWiki in $flashInstallSubwikis)
-    #set ($groupsFilter = [])
-    #foreach ($groupReference in $groups)
-      ## Remove the wiki component from the group reference if it matches the current wiki (where we look for flash
-      ## messages) because that's what we save in the groups property of flash messages.
-      #if ("$groupReference.getWikiReference().getName()" == $currentWiki)
-        #set ($compactGroupReference = $services.model.serialize($groupReference, 'local'))
+  #set ($query = $services.query.createQuery("object:Flash.FlashClass AND property.Flash.FlashClass.dateBegin:[* TO NOW] AND -property.Flash.FlashClass.dateEnd:[* TO NOW] AND property.Flash.FlashClass.subwikis:*${doc.getWiki()}(,|\r)* $groupsFilter", 'solr').bindValue('fq', 'type:DOCUMENT AND -fullname:Flash.FlashTemplate'))
+  #set ($queryResults = $query.setLimit(20).execute().get(0).getResults())
+  ##
+  #foreach($event in $queryResults)
+    #set ($eventDocName    = "$event.wiki:$event.fullname")
+    ## If solr isn't up to date, don't include deleted flashmessages.
+    #if ($xwiki.exists($eventDocName))
+      #set ($dateBegin       = $event.get('property.Flash.FlashClass.dateBegin_sortDate'))
+      #set ($repeat          = $event.get('property.Flash.FlashClass.repeat_string')[0])
+      #set ($repeatInterval  = $event.get('property.Flash.FlashClass.repeatInterval_string')[0])
+      #set ($repeatFrequency = $numbertool.integer($event.get('property.Flash.FlashClass.repeatFrequency_string')[0]))
+      #set ($repeatDays      = $event.get('property.Flash.FlashClass.repeatDays_string'))
+      ##
+      #set ($today           = $datetool)
+      #set ($dayOfTheWeek    = $stringtool.lowerCase($datetool.format('EEEE', $today)))
+      #set ($dateDiff        = $datetool.difference($dateBegin, $today))
+      #if ($repeat == 1)
+        #if (($repeatInterval == 'daily'   &amp;&amp; $mathtool.mod($dateDiff.days,   $repeatFrequency) == 0) ||
+            ($repeatInterval == 'weekly'  &amp;&amp; $mathtool.mod($dateDiff.weeks,  $repeatFrequency) == 0 &amp;&amp; $repeatDays.contains($dayOfTheWeek)) ||
+            ($repeatInterval == 'monthly' &amp;&amp; $mathtool.mod($dateDiff.months, $repeatFrequency) == 0 &amp;&amp; $datetool.format('d', $dateBegin) == $datetool.format('d', $today)) ||
+            ($repeatInterval == 'yearly'  &amp;&amp; $mathtool.mod($dateDiff.years,  $repeatFrequency) == 0 &amp;&amp; $datetool.format('Md', $dateBegin) == $datetool.format('Md', $today))
+          )
+          #set($discard = $events.add({'doc' : $eventDocName, 'date' : $dateBegin}))
+        #end
       #else
-        #set ($compactGroupReference = $services.model.serialize($groupReference, 'default'))
-      #end
-      #set ($discard = $groupsFilter.add("'$compactGroupReference' member of obj.groups"))
-    #end
-    #if ($groupsFilter.size() &gt; 0)
-      #set ($groupsFilter = " AND ($stringtool.join($groupsFilter, ' OR ')) ")
-    #else
-      #set ($groupsFilter = '')
-    #end
-    ##
-    #set ($baseQuery = "select doc.fullName, obj.dateBegin {0}, obj.subwikis from Document doc, doc.object(Flash.FlashClass) as obj WHERE doc.fullName &lt;&gt; 'Flash.FlashTemplate' $!groupsFilter AND obj.dateBegin &lt;= :now AND (obj.dateEnd is null OR obj.dateEnd &gt; :now) {1} ORDER BY obj.dateBegin DESC")
-    #set ($nonRecurringQuery = $baseQuery.replace("{0}", "").replace("{1}", "AND (obj.repeat is null OR obj.repeat = 0)"))
-    #set ($nonRecurring = $services.query.xwql($nonRecurringQuery).bindValue('now', $dateNow).setLimit(3).setWiki($currentWiki).execute())
-    ##
-    #set ($recurringQuery = $baseQuery.replace("{0}", ", obj.repeatInterval, obj.repeatFrequency, obj.repeatDays ").replace("{1}", "AND obj.repeat = 1"))
-    #set ($recurring = $services.query.xwql($recurringQuery).bindValue('now', $dateNow).setWiki($currentWiki).execute())
-    ##
-    #foreach($event in $nonRecurring)
-      #set ($subwikis = $stringtool.split($event[2], '|'))
-      #if ($subwikis.contains($doc.getWiki()))
-        #set($discard = $events.add({'doc' : "$currentWiki:$event[0]", 'date' : $event[1]}))
-      #end
-    #end
-    ##
-    #foreach($event in $recurring)
-      #set($document        = $event[0])
-      #set($date            = $event[1])
-      #set($repeatInterval  = $event[2])
-      #set($repeatFrequency = $numbertool.integer($event[3]))
-      #set($repeatDays      = $stringtool.split($event[4], '|'))
-      #set ($subwikis       = $stringtool.split($event[5], '|'))
-      ##
-      #set($today           = $datetool)
-      #set($dayOfTheWeek    = $stringtool.lowerCase($datetool.format('EEEE', $today)))
-      #set($dateDiff        = $datetool.difference($date, $today))
-      ##
-      #if($subwikis.contains($doc.getWiki()) &amp;&amp; (
-        ($repeatInterval == 'daily'   &amp;&amp; $mathtool.mod($dateDiff.days,   $repeatFrequency) == 0) ||
-        ($repeatInterval == 'weekly'  &amp;&amp; $mathtool.mod($dateDiff.weeks,  $repeatFrequency) == 0 &amp;&amp; $repeatDays.contains($dayOfTheWeek)) ||
-        ($repeatInterval == 'monthly' &amp;&amp; $mathtool.mod($dateDiff.months, $repeatFrequency) == 0 &amp;&amp; $datetool.format('d', $date) == $datetool.format('d', $today)) ||
-        ($repeatInterval == 'yearly'  &amp;&amp; $mathtool.mod($dateDiff.years,  $repeatFrequency) == 0 &amp;&amp; $datetool.format('Md', $date) == $datetool.format('Md', $today))
-      ))
-        #set($discard = $events.add({'doc' : "$currentWiki:$document", 'date' : $date}))
+        #set($discard = $events.add({'doc' : $eventDocName, 'date' : $dateBegin}))
       #end
     #end
   #end

--- a/application-flashmessages-ui/src/main/resources/Flash/DisplayFlashMessages.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/DisplayFlashMessages.xml
@@ -65,10 +65,12 @@
 #set ($groupsFilter = [])
 #foreach ($groupReference in $groups)
   ## Remove the wiki component from the group reference if it matches the wiki of the message.
-  #set ($compactGroupReferenceLocal = $services.model.serialize($groupReference, 'local'))
-  #set ($compactGroupReferenceFull  = $services.model.serialize($groupReference, 'default').replace(':','\:'))
+  #set ($groupReferenceCompact = $services.model.serialize($groupReference, 'local'))
+  #set ($groupReferenceFull  = $services.model.serialize($groupReference, 'default').replace(':','\:'))
   #set ($messageWiki = $groupReference.getWikiReference().getName())
-  #set ($discard = $groupsFilter.add("(wiki:$messageWiki AND property.Flash.FlashClass.groups:*(?&lt;!\:)$compactGroupReferenceLocal(,|\r)*) OR (-wiki:$messageWiki AND property.Flash.FlashClass.groups:*$compactGroupReferenceFull(,|\r)*)"))
+  #set ($discard = $groupsFilter.add(
+    "(wiki:$messageWiki AND property.Flash.FlashClass.groups:*(?&lt;!\:)$groupReferenceCompact(,|\r)*)
+    OR (-wiki:$messageWiki AND property.Flash.FlashClass.groups:*$groupReferenceFull(,|\r)*)"))
 #end
 #if ($groupsFilter.size() &gt; 0)
   #set ($groupsFilter = " AND ($stringtool.join($groupsFilter, ' OR ')) ")
@@ -84,7 +86,11 @@
 ## If the user is not in any group then no message should be displayed
 #if($groups.size() &gt; 0)
   #set($events = [])
-  #set ($query = $services.query.createQuery("object:Flash.FlashClass AND property.Flash.FlashClass.dateBegin:[* TO NOW] AND -property.Flash.FlashClass.dateEnd:[* TO NOW] AND (wiki:$doc.getWiki() OR property.Flash.FlashClass.subwikis:all) $groupsFilter", 'solr').bindValue('fq', 'type:DOCUMENT AND -fullname:Flash.FlashTemplate'))
+  #set ($query = $services.query.createQuery(
+    "object:Flash.FlashClass AND property.Flash.FlashClass.dateBegin:[* TO NOW]
+    AND -property.Flash.FlashClass.dateEnd:[* TO NOW]
+    AND (wiki:$doc.getWiki() OR property.Flash.FlashClass.wikiScope:allWikis)
+    $groupsFilter", 'solr').bindValue('fq', 'type:DOCUMENT AND -fullname:Flash.FlashTemplate'))
   #set ($queryResults = $query.setLimit(20).execute().get(0).getResults())
   ##
   #foreach($event in $queryResults)

--- a/application-flashmessages-ui/src/main/resources/Flash/DisplayFlashMessages.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/DisplayFlashMessages.xml
@@ -156,7 +156,7 @@
 ##            DISPLAY ALERT
 ###############################################
 #set($userDoc = $xwiki.getDocument($xcontext.user))
-#set ($userLocalString = services.model.serialize($userDoc, 'local'))
+#set ($userLocalString = $services.model.serialize($userDoc, 'local'))
 #set($userValObj = $userDoc.getObject('Flash.FlashValidationClass'))
 #set($userValList = $userValObj.getProperty('flash').getValue())
 #set($need = [])

--- a/application-flashmessages-ui/src/main/resources/Flash/DisplayFlashMessages.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/DisplayFlashMessages.xml
@@ -68,7 +68,7 @@
   #set ($compactGroupReferenceLocal = $services.model.serialize($groupReference, 'local'))
   #set ($compactGroupReferenceFull  = $services.model.serialize($groupReference, 'default').replace(':','\:'))
   #set ($messageWiki = $groupReference.getWikiReference().getName())
-  #set ($discard = $groupsFilter.add("(wiki:$messageWiki AND property.Flash.FlashClass.groups:*$compactGroupReferenceLocal(,|\r)*) OR (-wiki:$messageWiki AND property.Flash.FlashClass.groups:*$compactGroupReferenceFull(,|\r)*)"))
+  #set ($discard = $groupsFilter.add("(wiki:$messageWiki AND property.Flash.FlashClass.groups:*(?&lt;!\:)$compactGroupReferenceLocal(,|\r)*) OR (-wiki:$messageWiki AND property.Flash.FlashClass.groups:*$compactGroupReferenceFull(,|\r)*)"))
 #end
 #if ($groupsFilter.size() &gt; 0)
   #set ($groupsFilter = " AND ($stringtool.join($groupsFilter, ' OR ')) ")
@@ -84,7 +84,7 @@
 ## If the user is not in any group then no message should be displayed
 #if($groups.size() &gt; 0)
   #set($events = [])
-  #set ($query = $services.query.createQuery("object:Flash.FlashClass AND property.Flash.FlashClass.dateBegin:[* TO NOW] AND -property.Flash.FlashClass.dateEnd:[* TO NOW] AND property.Flash.FlashClass.subwikis:*${doc.getWiki()}(,|\r)* $groupsFilter", 'solr').bindValue('fq', 'type:DOCUMENT AND -fullname:Flash.FlashTemplate'))
+  #set ($query = $services.query.createQuery("object:Flash.FlashClass AND property.Flash.FlashClass.dateBegin:[* TO NOW] AND -property.Flash.FlashClass.dateEnd:[* TO NOW] AND (wiki:$doc.getWiki() OR property.Flash.FlashClass.subwikis:all) $groupsFilter", 'solr').bindValue('fq', 'type:DOCUMENT AND -fullname:Flash.FlashTemplate'))
   #set ($queryResults = $query.setLimit(20).execute().get(0).getResults())
   ##
   #foreach($event in $queryResults)
@@ -126,7 +126,7 @@
             #set($obj = $document.getObject('Flash.FlashClass'))
             &lt;li class="unit"&gt;
               #if ($hasAdmin)
-                &lt;span class="subwiki"&gt;[[$!services.rendering.escape($escapetool.xml($services.wiki.getById($document.getWiki()).getPrettyName()), 'xwiki/2.1')&gt;&gt;$!services.wiki.getById($document.getWiki()).getMainPageReference()]]&lt;/span&gt;&amp;nbsp;
+                &lt;span class="subwiki"&gt;[[$!services.rendering.escape($escapetool.xml($services.wiki.getById($document.getWiki()).getPrettyName()), 'xwiki/2.1')&gt;&gt;$document.getWiki():Flash.WebHome]]&lt;/span&gt;&amp;nbsp;
               #end
               &lt;span class="date"&gt;$!services.rendering.escape($!obj.display('dateBegin', 'view'), 'xwiki/2.1') : &lt;/span&gt;
               &lt;span class="message"&gt;$!services.rendering.escape($!obj.display('message', 'view'), 'xwiki/2.1')&lt;/span&gt;

--- a/application-flashmessages-ui/src/main/resources/Flash/DisplayFlashMessages.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/DisplayFlashMessages.xml
@@ -92,7 +92,7 @@
     ## If solr isn't up to date, don't include deleted flashmessages.
     #if ($xwiki.exists($eventDocName))
       #set ($dateBegin       = $event.get('property.Flash.FlashClass.dateBegin_sortDate'))
-      #set ($repeat          = $event.get('property.Flash.FlashClass.repeat_string')[0])
+      #set ($repeat          = $event.get('property.Flash.FlashClass.repeat_boolean')[0])
       #set ($repeatInterval  = $event.get('property.Flash.FlashClass.repeatInterval_string')[0])
       #set ($repeatFrequency = $numbertool.integer($event.get('property.Flash.FlashClass.repeatFrequency_string')[0]))
       #set ($repeatDays      = $event.get('property.Flash.FlashClass.repeatDays_string'))
@@ -100,7 +100,7 @@
       #set ($today           = $datetool)
       #set ($dayOfTheWeek    = $stringtool.lowerCase($datetool.format('EEEE', $today)))
       #set ($dateDiff        = $datetool.difference($dateBegin, $today))
-      #if ($repeat == 1)
+      #if ($repeat == true)
         #if (($repeatInterval == 'daily'   &amp;&amp; $mathtool.mod($dateDiff.days,   $repeatFrequency) == 0) ||
             ($repeatInterval == 'weekly'  &amp;&amp; $mathtool.mod($dateDiff.weeks,  $repeatFrequency) == 0 &amp;&amp; $repeatDays.contains($dayOfTheWeek)) ||
             ($repeatInterval == 'monthly' &amp;&amp; $mathtool.mod($dateDiff.months, $repeatFrequency) == 0 &amp;&amp; $datetool.format('d', $dateBegin) == $datetool.format('d', $today)) ||
@@ -126,7 +126,7 @@
             #set($obj = $document.getObject('Flash.FlashClass'))
             &lt;li class="unit"&gt;
               #if ($hasAdmin)
-                &lt;span class="subwiki"&gt;[[$document.getWiki()&gt;&gt;$!services.wiki.getById($document.getWiki()).getMainPageReference()]]&lt;/span&gt;&amp;nbsp;
+                &lt;span class="subwiki"&gt;[[$!services.rendering.escape($escapetool.xml($services.wiki.getById($document.getWiki()).getPrettyName()), 'xwiki/2.1')&gt;&gt;$!services.wiki.getById($document.getWiki()).getMainPageReference()]]&lt;/span&gt;&amp;nbsp;
               #end
               &lt;span class="date"&gt;$!services.rendering.escape($!obj.display('dateBegin', 'view'), 'xwiki/2.1') : &lt;/span&gt;
               &lt;span class="message"&gt;$!services.rendering.escape($!obj.display('message', 'view'), 'xwiki/2.1')&lt;/span&gt;

--- a/application-flashmessages-ui/src/main/resources/Flash/DisplayFlashMessages.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/DisplayFlashMessages.xml
@@ -138,7 +138,9 @@
             #set($document = $xwiki.getDocument($r.doc))
             #set($obj = $document.getObject('Flash.FlashClass'))
             &lt;li class="unit"&gt;
-              &lt;span class="subwiki"&gt;[[$document.getWiki()&gt;&gt;$!services.wiki.getById($document.getWiki()).getMainPageReference()]]&lt;/span&gt;
+              #if ($hasAdmin)
+                &lt;span class="subwiki"&gt;[[$document.getWiki()&gt;&gt;$!services.wiki.getById($document.getWiki()).getMainPageReference()]]&lt;/span&gt;&amp;nbsp;
+              #end
               &lt;span class="date"&gt;$!services.rendering.escape($!obj.display('dateBegin', 'view'), 'xwiki/2.1') : &lt;/span&gt;
               &lt;span class="message"&gt;$!services.rendering.escape($!obj.display('message', 'view'), 'xwiki/2.1')&lt;/span&gt;
             &lt;/li&gt;
@@ -154,6 +156,7 @@
 ##            DISPLAY ALERT
 ###############################################
 #set($userDoc = $xwiki.getDocument($xcontext.user))
+#set ($userLocalString = services.model.serialize($userDoc, 'local'))
 #set($userValObj = $userDoc.getObject('Flash.FlashValidationClass'))
 #set($userValList = $userValObj.getProperty('flash').getValue())
 #set($need = [])
@@ -165,8 +168,14 @@
   #set ($seenDate = $msgValObj.getValue('seenDate'))
   #set ($wasSeenToday = $datetool.format($dateFormat, $dateNow) == $datetool.format($dateFormat, $seenDate))
   #set ($doRepeatEntry = $msgDoc.getObject('Flash.FlashClass').getValue('repeat') == 1)
+  ## If viewed from one subwiki and the message is from another subwiki, user references are serialized differently.
+  #if ($msgDoc.getWiki() == $userDoc.getWiki())
+    #set ($userStr = $userLocalString)
+  #else
+    #set ($userStr = $xcontext.user)
+  #end
   ## Check if the message was already seen by this user or if it wasn't seen today, for entries with repeat selected.
-  #if ((!$userValList.contains($msg.doc) &amp;&amp; !$msgValList.contains($xcontext.user))
+  #if ((!$userValList.contains($msg.doc) &amp;&amp; !$msgValList.contains($userStr))
       || (!$wasSeenToday &amp;&amp; $doRepeatEntry))
     #set ($discard = $need.add($msg.doc))
   #end
@@ -192,11 +201,14 @@
     }
   #end
     ];
-    // This is a workaround for https://jira.xwiki.org/browse/XWIKI-20623 : JS function XWiki.Document#getURL does not take into account the wiki name
-    fetch('/xwiki/rest/wikis').then(res =&gt; res.json())
+    // This is a workaround for XWIKI-20623 : JS function XWiki.Document#getURL does not take into account the wiki name
+    fetch('/xwiki/rest/wikis').then(res =&gt; res.text())
     .then(data =&gt; {
-      let flashNotifierUrl = '/xwiki/__subwiki__/jsx/Flash/FlashNotifier?r=1';
-      flashNotifierUrl = flashNotifierUrl.replace('__subwiki__', data.wikis.size() &gt; 1 ? 'wiki/$flashInstallSubwiki' : 'bin');
+      data = (new DOMParser()).parseFromString(data, "text/xml");
+      let wikis = Array.from(data.activeElement.getElementsByTagName('id')).map(a =&gt; a.innerHTML);
+      let flashNotifierUrl = '/xwiki/__subwiki__/jsx/Flash/FlashNotifier';
+      flashNotifierUrl = flashNotifierUrl.replace('__subwiki__', wikis.length &gt; 1 ? 'wiki/$flashInstallSubwiki' : 'bin');
+      // End workaround.
       require.config({
         'paths': {
            'flashNotifier': flashNotifierUrl
@@ -224,8 +236,12 @@
         &lt;div&gt;&lt;/div&gt;
       &lt;/div&gt;
       &lt;div class="modal-footer"&gt;
+        ## Workaround for the translation not working on subwikis without flashmessages installed.
+        #set ($temp = $xcontext.wiki)
+        #set ($xcontext.wiki = $flashInstallSubwiki)
         &lt;input type="button" class="btn btn-primary" disabled="disabled"
           value="$escapetool.xml($services.localization.render('flash.flashmessages.confirm'))"/&gt;
+        #set ($xcontext.wiki = $temp)
       &lt;/div&gt;
     &lt;/div&gt;
   &lt;/div&gt;

--- a/application-flashmessages-ui/src/main/resources/Flash/DisplayFlashMessages.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/DisplayFlashMessages.xml
@@ -36,15 +36,27 @@
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
-  <content>{{include reference="Flash.Macros"/}}
-
-{{velocity}}
+  <content>{{velocity}}
+#set ($searchFlashInstallation = $collectiontool.getOrderedSet())
+## Custom configurations for the app will be applied from the local wiki, then main wiki, then any other place where the FlashMessages app is installed.
+#set ($discard = $searchFlashInstallation.addAll([$doc.getWiki(), $services.wiki.getMainWikiId()]))
+#set ($discard = $searchFlashInstallation.addAll($services.wiki.getAllIds()))
+#set ($flashInstallSubwikis = [])
+#foreach ($subwiki in $searchFlashInstallation)
+  #if ($xwiki.exists("$subwiki:Flash.DisplayFlashMessages") &amp;&amp; $xwiki.hasAccessLevel('view', $xcontext.userReference, "$subwiki:Flash.DisplayFlashMessages"))
+    #set ($discard = $flashInstallSubwikis.add($subwiki))
+  #end
+#end
+## The subwiki to use as the source of the extension documents, css, jsx.
+#set ($flashInstallSubwiki = $flashInstallSubwikis.get(0))
+{{include reference="$flashInstallSubwiki:Flash.Macros"/}}
 ##
 ###############################################
 ##           LOAD MESSAGE SLIDER
 ###############################################
-#set($discard = $xwiki.jsx.use('Flash.DisplayFlashMessages'))
-#set($discard = $xwiki.ssx.use('Flash.DisplayFlashMessages'))
+#set ($discard = $xwiki.jsx.use("$flashInstallSubwiki:Flash.FlashNotifier"))
+#set ($discard = $xwiki.jsx.use("$flashInstallSubwiki:Flash.DisplayFlashMessages"))
+#set ($discard = $xwiki.ssx.use("$flashInstallSubwiki:Flash.DisplayFlashMessages"))
 ##
 ###############################################
 ##           Group filter
@@ -61,18 +73,6 @@
   ## Local users are normally included only in local groups (from the same wiki).
   #set ($groups = $services.user.group.getGroupsFromMemberWiki($xcontext.userReference))
 #end
-#set ($groupsFilter = [])
-#foreach ($groupReference in $groups)
-  ## Remove the wiki component from the group reference if it matches the current wiki (where we look for flash
-  ## messages) because that's what we save in the groups property of flash messages.
-  #set ($compactGroupReference = $services.model.serialize($groupReference, 'compactwiki'))
-  #set ($discard = $groupsFilter.add("'$compactGroupReference' member of obj.groups"))
-#end
-#if ($groupsFilter.size() &gt; 0)
-  #set ($groupsFilter = " AND ($stringtool.join($groupsFilter, ' OR ')) ")
-#else
-  #set ($groupsFilter = '')
-#end
 ##
 ###############################################
 ##            DISPLAY MESSAGES
@@ -80,63 +80,85 @@
 #set($dateNow = $datetool.getSystemDate())
 ##
 ## If the user is not in any group then no message should be displayed
-#if("$!groupsFilter" != '')
-  #set($baseQuery = "select doc.fullName, obj.dateBegin {0}, obj.subwikis from Document doc, doc.object(Flash.FlashClass) as obj WHERE doc.fullName &lt;&gt; 'Flash.FlashTemplate' $!groupsFilter AND obj.dateBegin &lt;= :now AND (obj.dateEnd is null OR obj.dateEnd &gt; :now) {1} ORDER BY obj.dateBegin DESC")
-  ##
-  #set($nonRecurringQuery = $baseQuery.replace("{0}", "").replace("{1}", "AND (obj.repeat is null OR obj.repeat = 0)"))
-  #set($nonRecurring = $services.query.xwql($nonRecurringQuery).bindValue('now', $dateNow).setLimit(3).execute())
-  ##
-  #set($recurringQuery = $baseQuery.replace("{0}", ", obj.repeatInterval, obj.repeatFrequency, obj.repeatDays ").replace("{1}", "AND obj.repeat = 1"))
-  #set($recurring = $services.query.xwql($recurringQuery).bindValue('now', $dateNow).execute())
-  ##
+#if($groups.size() &gt; 0)
   #set($events = [])
-  #foreach($event in $nonRecurring)
-    #set ($subwikis = $stringtool.split($event[2], '|'))
-    #if ($subwikis.contains($doc.getWiki()))
-      #set($discard = $events.add({'doc' : $event[0], 'date' : $event[1]}))
+  ## Go through all subwikis which have the FlashMessages app installed.
+  #foreach ($currentWiki in $flashInstallSubwikis)
+    #set ($groupsFilter = [])
+    #foreach ($groupReference in $groups)
+      ## Remove the wiki component from the group reference if it matches the current wiki (where we look for flash
+      ## messages) because that's what we save in the groups property of flash messages.
+      #if ("$groupReference.getWikiReference().getName()" == $currentWiki)
+        #set ($compactGroupReference = $services.model.serialize($groupReference, 'local'))
+      #else
+        #set ($compactGroupReference = $services.model.serialize($groupReference, 'default'))
+      #end
+      #set ($discard = $groupsFilter.add("'$compactGroupReference' member of obj.groups"))
     #end
-  #end
-  ##
-  #foreach($event in $recurring)
-    #set($document        = $event[0])
-    #set($date            = $event[1])
-    #set($repeatInterval  = $event[2])
-    #set($repeatFrequency = $numbertool.integer($event[3]))
-    #set($repeatDays      = $stringtool.split($event[4], '|'))
-    #set ($subwikis       = $stringtool.split($event[5], '|'))
+    #if ($groupsFilter.size() &gt; 0)
+      #set ($groupsFilter = " AND ($stringtool.join($groupsFilter, ' OR ')) ")
+    #else
+      #set ($groupsFilter = '')
+    #end
     ##
-    #set($today           = $datetool)
-    #set($dayOfTheWeek    = $stringtool.lowerCase($datetool.format('EEEE', $today)))
-    #set($dateDiff        = $datetool.difference($date, $today))
+    #set ($baseQuery = "select doc.fullName, obj.dateBegin {0}, obj.subwikis from Document doc, doc.object(Flash.FlashClass) as obj WHERE doc.fullName &lt;&gt; 'Flash.FlashTemplate' $!groupsFilter AND obj.dateBegin &lt;= :now AND (obj.dateEnd is null OR obj.dateEnd &gt; :now) {1} ORDER BY obj.dateBegin DESC")
+    #set ($nonRecurringQuery = $baseQuery.replace("{0}", "").replace("{1}", "AND (obj.repeat is null OR obj.repeat = 0)"))
+    #set ($nonRecurring = $services.query.xwql($nonRecurringQuery).bindValue('now', $dateNow).setLimit(3).setWiki($currentWiki).execute())
     ##
-    #if($subwikis.contains($doc.getWiki()) &amp;&amp; (
-      ($repeatInterval == 'daily'   &amp;&amp; $mathtool.mod($dateDiff.days,   $repeatFrequency) == 0) ||
-      ($repeatInterval == 'weekly'  &amp;&amp; $mathtool.mod($dateDiff.weeks,  $repeatFrequency) == 0 &amp;&amp; $repeatDays.contains($dayOfTheWeek)) ||
-      ($repeatInterval == 'monthly' &amp;&amp; $mathtool.mod($dateDiff.months, $repeatFrequency) == 0 &amp;&amp; $datetool.format('d', $date) == $datetool.format('d', $today)) ||
-      ($repeatInterval == 'yearly'  &amp;&amp; $mathtool.mod($dateDiff.years,  $repeatFrequency) == 0 &amp;&amp; $datetool.format('Md', $date) == $datetool.format('Md', $today))
-    ))
-      #set($discard = $events.add({'doc' : $document, 'date' : $date}))
+    #set ($recurringQuery = $baseQuery.replace("{0}", ", obj.repeatInterval, obj.repeatFrequency, obj.repeatDays ").replace("{1}", "AND obj.repeat = 1"))
+    #set ($recurring = $services.query.xwql($recurringQuery).bindValue('now', $dateNow).setWiki($currentWiki).execute())
+    ##
+    #foreach($event in $nonRecurring)
+      #set ($subwikis = $stringtool.split($event[2], '|'))
+      #if ($subwikis.contains($doc.getWiki()))
+        #set($discard = $events.add({'doc' : "$currentWiki:$event[0]", 'date' : $event[1]}))
+      #end
+    #end
+    ##
+    #foreach($event in $recurring)
+      #set($document        = $event[0])
+      #set($date            = $event[1])
+      #set($repeatInterval  = $event[2])
+      #set($repeatFrequency = $numbertool.integer($event[3]))
+      #set($repeatDays      = $stringtool.split($event[4], '|'))
+      #set ($subwikis       = $stringtool.split($event[5], '|'))
+      ##
+      #set($today           = $datetool)
+      #set($dayOfTheWeek    = $stringtool.lowerCase($datetool.format('EEEE', $today)))
+      #set($dateDiff        = $datetool.difference($date, $today))
+      ##
+      #if($subwikis.contains($doc.getWiki()) &amp;&amp; (
+        ($repeatInterval == 'daily'   &amp;&amp; $mathtool.mod($dateDiff.days,   $repeatFrequency) == 0) ||
+        ($repeatInterval == 'weekly'  &amp;&amp; $mathtool.mod($dateDiff.weeks,  $repeatFrequency) == 0 &amp;&amp; $repeatDays.contains($dayOfTheWeek)) ||
+        ($repeatInterval == 'monthly' &amp;&amp; $mathtool.mod($dateDiff.months, $repeatFrequency) == 0 &amp;&amp; $datetool.format('d', $date) == $datetool.format('d', $today)) ||
+        ($repeatInterval == 'yearly'  &amp;&amp; $mathtool.mod($dateDiff.years,  $repeatFrequency) == 0 &amp;&amp; $datetool.format('Md', $date) == $datetool.format('Md', $today))
+      ))
+        #set($discard = $events.add({'doc' : "$currentWiki:$document", 'date' : $date}))
+      #end
     #end
   #end
   ##
   #set($events = $collectiontool.sort($events, 'date:desc'))
   ##
   #if($events.size() &gt; 0)
-    {{html}}
+
+    {{html wiki="true"}}
       &lt;div id="flashMessages"&gt;
         &lt;ul class="messages"&gt;
           #foreach($r in $events)
             #set($document = $xwiki.getDocument($r.doc))
             #set($obj = $document.getObject('Flash.FlashClass'))
             &lt;li class="unit"&gt;
-              &lt;span class="date"&gt;$!obj.display('dateBegin', 'view') : &lt;/span&gt;
-              &lt;span class="message"&gt;$!obj.display('message', 'view')&lt;/span&gt;
+              &lt;span class="subwiki"&gt;[[$document.getWiki()&gt;&gt;$!services.wiki.getById($document.getWiki()).getMainPageReference()]]&lt;/span&gt;
+              &lt;span class="date"&gt;$!services.rendering.escape($!obj.display('dateBegin', 'view'), 'xwiki/2.1') : &lt;/span&gt;
+              &lt;span class="message"&gt;$!services.rendering.escape($!obj.display('message', 'view'), 'xwiki/2.1')&lt;/span&gt;
             &lt;/li&gt;
           #end
         &lt;/ul&gt;
         &lt;ul class="navigation"&gt;&lt;/ul&gt;
       &lt;/div&gt;
     {{/html}}
+
   #end
 #end
 ###############################################
@@ -182,14 +204,20 @@
     }
   #end
     ];
-    require.config({
-      'paths': {
-         'flashNotifier': new XWiki.Document('FlashNotifier', 'Flash').getURL('jsx', 'r=1')
-       }
-    });
-    require(['jquery', 'flashNotifier', 'bootstrap'], function($) {
-      window.flashPopup = $('#flashPopup');
-      window.flashNotifier(params);
+    // This is a workaround for https://jira.xwiki.org/browse/XWIKI-20623 : JS function XWiki.Document#getURL does not take into account the wiki name
+    fetch('/xwiki/rest/wikis').then(res =&gt; res.json())
+    .then(data =&gt; {
+      let flashNotifierUrl = '/xwiki/__subwiki__/jsx/Flash/FlashNotifier?r=1';
+      flashNotifierUrl = flashNotifierUrl.replace('__subwiki__', data.wikis.size() &gt; 1 ? 'wiki/$flashInstallSubwiki' : 'bin');
+      require.config({
+        'paths': {
+           'flashNotifier': flashNotifierUrl
+         }
+      });
+      require(['jquery', 'flashNotifier', 'bootstrap'], function($) {
+        window.flashPopup = $('#flashPopup');
+        window.flashNotifier(params);
+      });
     });
   });
   &lt;/script&gt;

--- a/application-flashmessages-ui/src/main/resources/Flash/DisplayFlashMessages.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/DisplayFlashMessages.xml
@@ -37,19 +37,8 @@
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
   <content>{{velocity}}
-#set ($searchFlashInstallation = $collectiontool.getOrderedSet())
-## Custom configurations for the app will be applied from the local wiki, then main wiki, then any other place where the FlashMessages app is installed.
-#set ($discard = $searchFlashInstallation.addAll([$doc.getWiki(), $services.wiki.getMainWikiId()]))
-#set ($discard = $searchFlashInstallation.addAll($services.wiki.getAllIds()))
-#set ($flashInstallSubwikis = [])
-#foreach ($subwiki in $searchFlashInstallation)
-  #if ($xwiki.exists("$subwiki:Flash.DisplayFlashMessages") &amp;&amp; $xwiki.hasAccessLevel('view', $xcontext.userReference, "$subwiki:Flash.DisplayFlashMessages"))
-    #set ($discard = $flashInstallSubwikis.add($subwiki))
-  #end
-#end
-## The subwiki to use as the source of the extension documents, css, jsx.
-#set ($flashInstallSubwiki = $flashInstallSubwikis.get(0))
-{{include reference="$flashInstallSubwiki:Flash.Macros"/}}
+## Variables $flashInstallSubwiki, $searchFlashInstallation are defined in Flash.FlashNotifier,
+## which includes this document.
 ##
 ###############################################
 ##           LOAD MESSAGE SLIDER
@@ -184,7 +173,6 @@
 #end
 #if(!$need.empty())
   ##
-
   {{html clean="false"}}
   &lt;script language="javascript"&gt;
   document.observe('xwiki:dom:loaded', function(){
@@ -224,7 +212,25 @@
   {{/html}}
 
 #end
-#showFlashPopup()
+{{html clean="false"}}
+&lt;div class="modal fade" id="flashPopup" tabindex="-1" role="dialog" aria-hidden="true"&gt;
+  &lt;div class="modal-dialog"&gt;
+    &lt;div class="modal-content"&gt;
+      &lt;div class="modal-header"&gt;
+        &lt;button type="button" class="close" data-dismiss="modal"&gt;&amp;times;&lt;/button&gt;
+        &lt;h4 class="modal-title"&gt;&lt;/h4&gt;
+      &lt;/div&gt;
+      &lt;div class="modal-body"&gt;
+        &lt;div&gt;&lt;/div&gt;
+      &lt;/div&gt;
+      &lt;div class="modal-footer"&gt;
+        &lt;input type="button" class="btn btn-primary" disabled="disabled"
+          value="$escapetool.xml($services.localization.render('flash.flashmessages.confirm'))"/&gt;
+      &lt;/div&gt;
+    &lt;/div&gt;
+  &lt;/div&gt;
+&lt;/div&gt;
+{{/html}}
 {{/velocity}}</content>
   <object>
     <name>Flash.DisplayFlashMessages</name>

--- a/application-flashmessages-ui/src/main/resources/Flash/FlashClass.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/FlashClass.xml
@@ -240,8 +240,7 @@
       <cache>0</cache>
       <customDisplay>{{velocity output="false"}}
 #template("pickers_macros.vm")
-{{/velocity}}
-{{velocity}}
+{{/velocity}}{{velocity}}
 #if ($type == 'edit')
     #set ($options = [{'name': $services.localization.render('flash.subwikis.empty'), 'value': ''}])
     #foreach ($subwiki in $services.wiki.getAll())

--- a/application-flashmessages-ui/src/main/resources/Flash/FlashClass.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/FlashClass.xml
@@ -236,6 +236,58 @@
       <values>daily|weekly|monthly|yearly</values>
       <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
     </repeatInterval>
+    <subwikis>
+      <cache>0</cache>
+      <customDisplay>{{velocity output="false"}}
+#template("pickers_macros.vm")
+{{/velocity}}
+{{velocity}}
+#if ($type == 'edit')
+    #set ($options = [{'name': $services.localization.render('flash.subwikis.empty'), 'value': ''}])
+    #foreach ($subwiki in $services.wiki.getAll())
+      #if ($xcontext.hasAccessLevel('admin', "${subwiki.getId()}:XWiki.XWikiPreferences"))
+        #set ($discard = $options.add({ 'name': $subwiki.getPrettyName(), 'value': $subwiki.getId()}))
+      #end
+    #end
+    #set ($parameters = {
+      'name': "${object.getxWikiClass().name}_${object.number}_${name}",
+      'value': $value,
+      'multiple': 'multiple',
+      'prefix': ' ',
+      'options': $options
+    })
+{{html}}
+    #staticSelectPicker($parameters)
+{{/html}}
+#elseif ($type == 'view')
+  #foreach ($subwiki in $value)
+    #set ($subwiki = $services.wiki.getById($subwiki))##
+[[$services.rendering.escape($services.rendering.escape($subwiki.getPrettyName(), 'xwiki/2.1'), 'xwiki/2.1')&gt;&gt;$services.rendering.escape($subwiki.getMainPageReference(), 'xwiki/2.1')]] ##
+  #end
+#end
+{{/velocity}}</customDisplay>
+      <defaultValue/>
+      <disabled>0</disabled>
+      <displayType>select</displayType>
+      <freeText/>
+      <hint>Only wikis you have Admin rights on are listed.</hint>
+      <largeStorage>0</largeStorage>
+      <multiSelect>1</multiSelect>
+      <name>subwikis</name>
+      <number>9</number>
+      <picker>1</picker>
+      <prettyName>Subwikis</prettyName>
+      <relationalStorage>0</relationalStorage>
+      <separator> </separator>
+      <separators>|, </separators>
+      <size>1</size>
+      <sort/>
+      <unmodifiable>0</unmodifiable>
+      <validationMessage/>
+      <validationRegExp/>
+      <values/>
+      <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+    </subwikis>
   </class>
   <object>
     <name>Flash.FlashClass</name>

--- a/application-flashmessages-ui/src/main/resources/Flash/FlashClass.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/FlashClass.xml
@@ -260,7 +260,7 @@
 {{/html}}
 #elseif ($type == 'view')
   #foreach ($subwiki in $value)
-    #set ($subwiki = $services.wiki.getById($subwiki))##
+    #set ($subwiki = $services.wiki.getById($subwiki))
 [[$services.rendering.escape($services.rendering.escape($subwiki.getPrettyName(), 'xwiki/2.1'), 'xwiki/2.1')&gt;&gt;$services.rendering.escape($subwiki.getMainPageReference(), 'xwiki/2.1')]] ##
   #end
 #end

--- a/application-flashmessages-ui/src/main/resources/Flash/FlashClass.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/FlashClass.xml
@@ -236,20 +236,20 @@
       <values>daily|weekly|monthly|yearly</values>
       <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
     </repeatInterval>
-    <subwikis>
+    <wikiScope>
       <cache>0</cache>
       <customDisplay/>
-      <defaultValue>current</defaultValue>
+      <defaultValue>currentWiki</defaultValue>
       <disabled>0</disabled>
       <displayType>select</displayType>
       <freeText/>
       <hint/>
       <largeStorage>0</largeStorage>
       <multiSelect>0</multiSelect>
-      <name>subwikis</name>
+      <name>wikiScope</name>
       <number>9</number>
       <picker>1</picker>
-      <prettyName>Subwikis</prettyName>
+      <prettyName/>
       <relationalStorage>0</relationalStorage>
       <separator> </separator>
       <separators>|, </separators>
@@ -258,9 +258,9 @@
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
-      <values>current|all</values>
+      <values>currentWiki|allWikis</values>
       <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
-    </subwikis>
+    </wikiScope>
   </class>
   <object>
     <name>Flash.FlashClass</name>

--- a/application-flashmessages-ui/src/main/resources/Flash/FlashClass.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/FlashClass.xml
@@ -250,6 +250,7 @@
     #end
     #set ($parameters = {
       'name': "${object.getxWikiClass().name}_${object.number}_${name}",
+      'id': "${object.getxWikiClass().name}_${object.number}_${name}",
       'value': $value,
       'multiple': 'multiple',
       'prefix': ' ',

--- a/application-flashmessages-ui/src/main/resources/Flash/FlashClass.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/FlashClass.xml
@@ -238,41 +238,14 @@
     </repeatInterval>
     <subwikis>
       <cache>0</cache>
-      <customDisplay>{{velocity output="false"}}
-#template("pickers_macros.vm")
-{{/velocity}}{{velocity}}
-#if ($type == 'edit')
-    #set ($options = [{'name': $services.localization.render('flash.subwikis.empty'), 'value': ''}])
-    #foreach ($subwiki in $services.wiki.getAll())
-      #if ($xcontext.hasAccessLevel('admin', "${subwiki.getId()}:XWiki.XWikiPreferences"))
-        #set ($discard = $options.add({ 'name': $subwiki.getPrettyName(), 'value': $subwiki.getId()}))
-      #end
-    #end
-    #set ($parameters = {
-      'name': "${object.getxWikiClass().name}_${object.number}_${name}",
-      'id': "${object.getxWikiClass().name}_${object.number}_${name}",
-      'value': $value,
-      'multiple': 'multiple',
-      'prefix': ' ',
-      'options': $options
-    })
-{{html}}
-    #staticSelectPicker($parameters)
-{{/html}}
-#elseif ($type == 'view')
-  #foreach ($subwiki in $value)
-    #set ($subwiki = $services.wiki.getById($subwiki))
-[[$services.rendering.escape($services.rendering.escape($subwiki.getPrettyName(), 'xwiki/2.1'), 'xwiki/2.1')&gt;&gt;$services.rendering.escape($subwiki.getMainPageReference(), 'xwiki/2.1')]] ##
-  #end
-#end
-{{/velocity}}</customDisplay>
-      <defaultValue/>
+      <customDisplay/>
+      <defaultValue>current</defaultValue>
       <disabled>0</disabled>
       <displayType>select</displayType>
       <freeText/>
-      <hint>Only wikis you have Admin rights on are listed.</hint>
+      <hint/>
       <largeStorage>0</largeStorage>
-      <multiSelect>1</multiSelect>
+      <multiSelect>0</multiSelect>
       <name>subwikis</name>
       <number>9</number>
       <picker>1</picker>
@@ -285,7 +258,7 @@
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
-      <values/>
+      <values>current|all</values>
       <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
     </subwikis>
   </class>

--- a/application-flashmessages-ui/src/main/resources/Flash/FlashNotifier.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/FlashNotifier.xml
@@ -421,14 +421,7 @@
     <property>
       <content>{{velocity}}
 ## Don't initialize twice if there is another flashmessages installation on this subwiki.
-## The global extension point is initialized first, so we need to check for local extension points for flash &lt;= 1.8.1.
-#set ($flasmessagesVersion =
-  $services.extension.installed.getInstalledExtension('com.xwiki.flashmessages:application-flashmessages-ui',
-  "wiki:$services.wiki.currentWikiId").getLocalExtension().getId().getVersion())
-#if ("$!flasmessagesVersion" != '')
-  #set ($flashmessagesAreLocal = $flasmessagesVersion.compareTo('1.8.1') &lt;= 0)
-#end
-#if(!$flashmessagesAreLocal &amp;&amp; !$flashMessagesUIXPInitialized &amp;&amp; $xcontext.action == 'view')
+#if (!$flashMessagesUIXPInitialized &amp;&amp; $xcontext.action == 'view')
   ## The subwiki to use as the source of the extension documents, css, jsx.
   #set ($flashMessagesUIXPInitialized = 1)
   #set ($searchFlashInstallation = $collectiontool.getOrderedSet())

--- a/application-flashmessages-ui/src/main/resources/Flash/FlashNotifier.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/FlashNotifier.xml
@@ -198,15 +198,23 @@
    */
   window.flashNotifierConfirm = function() {
     let params = window.flashNotifierParams[window.flashNotifierIndex];
-    url = new XWiki.Document('FlashNotifier', 'Flash').getURL('get');
-    return $.ajax({
-      url : url,
-      data : {'ajax' : '1', 'flash' : params['document']}
-    }).done(function() {
-      // Show the next popup when the current one is closed.
-      $(document).one('hidden.bs.modal', '#flashPopup', function(event) {
-        window.flashNotifierIndex++;
-        window.flashNotifierNext();
+    // Workaround for XWIKI-20623 : JS function XWiki.Document#getURL does not take into account the wiki name.
+    return fetch('/xwiki/rest/wikis').then(res =&gt; res.text())
+    .then(data =&gt; {
+      data = (new DOMParser()).parseFromString(data, "text/xml");
+      let wikis = Array.from(data.activeElement.getElementsByTagName('id')).map(a =&gt; a.innerHTML);
+      let flashNotifierUrl = '/xwiki/__subwiki__/get/Flash/FlashNotifier';
+      flashNotifierUrl = flashNotifierUrl.replace('__subwiki__', wikis.length &gt; 1 ? 'wiki/$doc.getWiki()' : 'bin');
+      // End workaround.
+      return $.ajax({
+        url : flashNotifierUrl,
+        data : {'ajax' : '1', 'flash' : params['document']}
+      }).done(function() {
+        // Show the next popup when the current one is closed.
+        $(document).one('hidden.bs.modal', '#flashPopup', function(event) {
+          window.flashNotifierIndex++;
+          window.flashNotifierNext();
+        });
       });
     });
   };
@@ -226,10 +234,10 @@
   $(document).on('click', '#flashPopup input.btn-primary', function(event) {
     var okButton = $(this).prop('disabled', true);
     // Wait for the confirmation request to succeed and only then hide the popup.
-    window.flashNotifierConfirm().done(function() {
+    window.flashNotifierConfirm().then(function() {
       // Hide the current popup and possibly trigger the next popup.
       window.flashPopup.modal('hide');
-    }).fail(function() {
+    }).catch(function() {
       // Re-enable the OK button in case the confirmation request failed.
       okButton.prop('disabled', false);
     });
@@ -412,15 +420,26 @@
     </property>
     <property>
       <content>{{velocity}}
-#if(!$flashMessagesUIXPDisplayed &amp;&amp; $xcontext.action == 'view')
-  #set ($flashMessagesUIXPDisplayed = 1)
+## Don't initialize twice if there is another flashmessages installation on this subwiki.
+## The global extension point is initialized first, so we need to check for local extension points for flash &lt;= 1.8.1.
+#set ($flasmessagesVersion =
+  $services.extension.installed.getInstalledExtension('com.xwiki.flashmessages:application-flashmessages-ui',
+  "wiki:$services.wiki.currentWikiId").getLocalExtension().getId().getVersion())
+#if ("$!flasmessagesVersion" != '')
+  #set ($flashmessagesAreLocal = $flasmessagesVersion.compareTo('1.8.1') &lt;= 0)
+#end
+#if(!$flashmessagesAreLocal &amp;&amp; !$flashMessagesUIXPInitialized &amp;&amp; $xcontext.action == 'view')
+  ## The subwiki to use as the source of the extension documents, css, jsx.
+  #set ($flashMessagesUIXPInitialized = 1)
   #set ($searchFlashInstallation = $collectiontool.getOrderedSet())
-  ## Custom configurations for the app will be applied from the local wiki, then main wiki, then any other place where the FlashMessages app is installed.
+  ## Custom configurations for the app will be applied from the local wiki, then main wiki,
+  ## then any other place where the FlashMessages app is installed.
   #set ($discard = $searchFlashInstallation.addAll([$doc.getWiki(), $services.wiki.getMainWikiId()]))
   #set ($discard = $searchFlashInstallation.addAll($services.wiki.getAllIds()))
   #set ($flashInstallSubwikis = [])
   #foreach ($subwiki in $searchFlashInstallation)
-    #if ($xwiki.exists("$subwiki:Flash.DisplayFlashMessages") &amp;&amp; $xwiki.hasAccessLevel('view', $xcontext.userReference, "$subwiki:Flash.DisplayFlashMessages"))
+    #if ($xwiki.exists("$subwiki:Flash.DisplayFlashMessages")
+        &amp;&amp; $xwiki.hasAccessLevel('view', $xcontext.userReference, "$subwiki:Flash.DisplayFlashMessages"))
       #set ($discard = $flashInstallSubwikis.add($subwiki))
     #end
   #end

--- a/application-flashmessages-ui/src/main/resources/Flash/FlashNotifier.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/FlashNotifier.xml
@@ -412,7 +412,8 @@
     </property>
     <property>
       <content>{{velocity}}
-#if(!$flashInstallSubwiki &amp;&amp; $xcontext.action == 'view')
+#if(!$flashMessagesUIXPDisplayed &amp;&amp; $xcontext.action == 'view')
+  #set ($flashMessagesUIXPDisplayed = 1)
   #set ($searchFlashInstallation = $collectiontool.getOrderedSet())
   ## Custom configurations for the app will be applied from the local wiki, then main wiki, then any other place where the FlashMessages app is installed.
   #set ($discard = $searchFlashInstallation.addAll([$doc.getWiki(), $services.wiki.getMainWikiId()]))
@@ -420,13 +421,13 @@
   #set ($flashInstallSubwikis = [])
   #foreach ($subwiki in $searchFlashInstallation)
     #if ($xwiki.exists("$subwiki:Flash.DisplayFlashMessages") &amp;&amp; $xwiki.hasAccessLevel('view', $xcontext.userReference, "$subwiki:Flash.DisplayFlashMessages"))
-      #set ($flashInstallSubwiki = $subwiki)
-      #break
+      #set ($discard = $flashInstallSubwikis.add($subwiki))
     #end
   #end
+  ## The subwiki to use as the source of the extension documents, css, jsx.
+  #set ($flashInstallSubwiki = $flashInstallSubwikis.get(0))
   {{include reference='$flashInstallSubwiki:Flash.DisplayFlashMessages' /}}
 #end
-#set ($flashMessagesUIXPDisplayed = 1)
 {{/velocity}}</content>
     </property>
     <property>

--- a/application-flashmessages-ui/src/main/resources/Flash/FlashNotifier.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/FlashNotifier.xml
@@ -412,21 +412,19 @@
     </property>
     <property>
       <content>{{velocity}}
-{{html}}
-$flashMessagesUIXPDisplayed
-$xcontext.action
-$xwiki.hasAccessLevel('view', $xcontext.userReference, 'Flash.DisplayFlashMessages')
-$xwiki.exists('Flash.DisplayFlashMessages')
-{{/html}}
-#set ($mainWiki = 'xwiki')
-#if($flashMessagesUIXPDisplayed != 1 &amp;&amp; $xcontext.action == 'view')
-  #if ($xwiki.exists('Flash.DisplayFlashMessages') &amp;&amp; $xwiki.hasAccessLevel('view', $xcontext.userReference, 'Flash.DisplayFlashMessages'))
-    {{include reference='Flash.DisplayFlashMessages' /}}
-  #elseif ($xwiki.exists("$mainWiki:Flash.DisplayFlashMessages") &amp;&amp; $xwiki.hasAccessLevel('view', $xcontext.userReference, "$mainWiki:Flash.DisplayFlashMessages"))
-    ## This breaks the DisplayFlashMessages page, because it is looking for the pages in the current wiki.
-    ## TODO FIXME Fix this: Either add a wiki parameter, force install on main wiki always, or do something more complex.
-    {{include reference='xwiki:Flash.DisplayFlashMessages' /}}
+#if(!$flashInstallSubwiki &amp;&amp; $xcontext.action == 'view')
+  #set ($searchFlashInstallation = $collectiontool.getOrderedSet())
+  ## Custom configurations for the app will be applied from the local wiki, then main wiki, then any other place where the FlashMessages app is installed.
+  #set ($discard = $searchFlashInstallation.addAll([$doc.getWiki(), $services.wiki.getMainWikiId()]))
+  #set ($discard = $searchFlashInstallation.addAll($services.wiki.getAllIds()))
+  #set ($flashInstallSubwikis = [])
+  #foreach ($subwiki in $searchFlashInstallation)
+    #if ($xwiki.exists("$subwiki:Flash.DisplayFlashMessages") &amp;&amp; $xwiki.hasAccessLevel('view', $xcontext.userReference, "$subwiki:Flash.DisplayFlashMessages"))
+      #set ($flashInstallSubwiki = $subwiki)
+      #break
+    #end
   #end
+  {{include reference='$flashInstallSubwiki:Flash.DisplayFlashMessages' /}}
 #end
 #set ($flashMessagesUIXPDisplayed = 1)
 {{/velocity}}</content>

--- a/application-flashmessages-ui/src/main/resources/Flash/FlashNotifier.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/FlashNotifier.xml
@@ -425,20 +425,27 @@
   ## The subwiki to use as the source of the extension documents, css, jsx.
   #set ($flashMessagesUIXPInitialized = 1)
   #set ($searchFlashInstallation = $collectiontool.getOrderedSet())
-  ## Custom configurations for the app will be applied from the local wiki, then main wiki,
-  ## then any other place where the FlashMessages app is installed.
+  ## App pages will be loaded from a subwiki where the FlashMessages app is installed with a version > 1.8.1 .
+  ## Look in the current subwiki first, then main and the rest of the subwikis.
   #set ($discard = $searchFlashInstallation.addAll([$doc.getWiki(), $services.wiki.getMainWikiId()]))
   #set ($discard = $searchFlashInstallation.addAll($services.wiki.getAllIds()))
   #set ($flashInstallSubwikis = [])
   #foreach ($subwiki in $searchFlashInstallation)
-    #if ($xwiki.exists("$subwiki:Flash.DisplayFlashMessages")
+    #set ($flashmessagesVersion = $services.extension.installed.getInstalledExtension(
+      'com.xwiki.flashmessages:application-flashmessages-ui', "wiki:$subwiki").getId().getVersion())
+    #if ("$!flashmessagesVersion" != '')
+      #set ($supportsGlobalFlashmessages = $flashmessagesVersion.compareTo('1.8.1') &gt; 0)
+    #end
+    #if ($supportsGlobalFlashmessages &amp;&amp; $xwiki.exists("$subwiki:Flash.DisplayFlashMessages")
         &amp;&amp; $xwiki.hasAccessLevel('view', $xcontext.userReference, "$subwiki:Flash.DisplayFlashMessages"))
       #set ($discard = $flashInstallSubwikis.add($subwiki))
     #end
   #end
-  ## The subwiki to use as the source of the extension documents, css, jsx.
-  #set ($flashInstallSubwiki = $flashInstallSubwikis.get(0))
-  {{include reference='$flashInstallSubwiki:Flash.DisplayFlashMessages' /}}
+  #if ($flashInstallSubwikis.size() &gt; 0)
+    ## The subwiki to use as the source of the extension documents, css, jsx.
+    #set ($flashInstallSubwiki = $flashInstallSubwikis.get(0))
+    {{include reference='$flashInstallSubwiki:Flash.DisplayFlashMessages' /}}
+  #end
 #end
 {{/velocity}}</content>
     </property>

--- a/application-flashmessages-ui/src/main/resources/Flash/FlashNotifier.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/FlashNotifier.xml
@@ -412,9 +412,23 @@
     </property>
     <property>
       <content>{{velocity}}
-#if($xcontext.action == 'view' &amp;&amp; $xwiki.hasAccessLevel('view', $xcontext.userReference, 'Flash.DisplayFlashMessages'))
-  {{include reference='Flash.DisplayFlashMessages' /}}
+{{html}}
+$flashMessagesUIXPDisplayed
+$xcontext.action
+$xwiki.hasAccessLevel('view', $xcontext.userReference, 'Flash.DisplayFlashMessages')
+$xwiki.exists('Flash.DisplayFlashMessages')
+{{/html}}
+#set ($mainWiki = 'xwiki')
+#if($flashMessagesUIXPDisplayed != 1 &amp;&amp; $xcontext.action == 'view')
+  #if ($xwiki.exists('Flash.DisplayFlashMessages') &amp;&amp; $xwiki.hasAccessLevel('view', $xcontext.userReference, 'Flash.DisplayFlashMessages'))
+    {{include reference='Flash.DisplayFlashMessages' /}}
+  #elseif ($xwiki.exists("$mainWiki:Flash.DisplayFlashMessages") &amp;&amp; $xwiki.hasAccessLevel('view', $xcontext.userReference, "$mainWiki:Flash.DisplayFlashMessages"))
+    ## This breaks the DisplayFlashMessages page, because it is looking for the pages in the current wiki.
+    ## TODO FIXME Fix this: Either add a wiki parameter, force install on main wiki always, or do something more complex.
+    {{include reference='xwiki:Flash.DisplayFlashMessages' /}}
+  #end
 #end
+#set ($flashMessagesUIXPDisplayed = 1)
 {{/velocity}}</content>
     </property>
     <property>
@@ -427,7 +441,7 @@
       <parameters/>
     </property>
     <property>
-      <scope>wiki</scope>
+      <scope>global</scope>
     </property>
   </object>
 </xwikidoc>

--- a/application-flashmessages-ui/src/main/resources/Flash/FlashSheet.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/FlashSheet.xml
@@ -73,6 +73,13 @@
     (((
       (% class="col-sm-6" %)
       (((
+        #displayFlashProperty($obj 'subwikis')
+      )))
+    )))
+    (% class="row" %)
+    (((
+      (% class="col-sm-6" %)
+      (((
         ; &lt;label for="Flash.FlashClass_0_repeat"&gt;$doc.displayPrettyName('repeat', false, false)&lt;/label&gt;
         : #if($xcontext.action == 'view' &amp;&amp; $doc.getValue('repeat') == 1)
             #set($date      = $doc.getValue('dateBegin'))

--- a/application-flashmessages-ui/src/main/resources/Flash/FlashSheet.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/FlashSheet.xml
@@ -44,8 +44,13 @@
   #set($obj = $doc.getObject('Flash.FlashClass'))
   #set($discard = $doc.use('Flash.FlashClass'))
   #if ($obj.getProperty('subwikis').value.size() == 0)
-    {{warning}}$services.localization.render('flash.banner.subwikis.none'){{/warning}}
+    #if ($xcontext.action == 'edit' &amp;&amp; !$xwiki.exists($doc))
+      ## By default, newly created messages should be displayed on the current wiki.
+      #set ($discard = $obj.set('subwikis', $doc.getWiki()))
+    #else
+      {{warning}}$services.localization.render('flash.banner.subwikis.none'){{/warning}}
 
+    #end
   #end
   ## We don't have access to the form element to set the CSS class for the vertical form layout standard.
   #if("$!xcontext.action" == 'edit')
@@ -77,6 +82,10 @@
     (((
       (% class="col-sm-6" %)
       (((
+        #displayFlashProperty($obj 'groups')
+      )))
+      (% class="col-sm-6" %)
+      (((
         #displayFlashProperty($obj 'subwikis')
       )))
     )))
@@ -94,10 +103,6 @@
           #else
             $doc.display('repeat')
           #end
-      )))
-      (% class="col-sm-6" %)
-      (((
-        #displayFlashProperty($obj 'groups')
       )))
     )))
     (% class="repeatSettings $!hideRepeatSettings" %)

--- a/application-flashmessages-ui/src/main/resources/Flash/FlashSheet.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/FlashSheet.xml
@@ -77,7 +77,7 @@
       )))
       (% class="col-sm-6" %)
       (((
-        #displayFlashProperty($obj 'subwikis')
+        #displayFlashProperty($obj 'wikiScope')
       )))
     )))
     (% class="row" %)

--- a/application-flashmessages-ui/src/main/resources/Flash/FlashSheet.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/FlashSheet.xml
@@ -43,6 +43,10 @@
 #if ($doc.getObject('Flash.FlashClass'))
   #set($obj = $doc.getObject('Flash.FlashClass'))
   #set($discard = $doc.use('Flash.FlashClass'))
+  #if ($obj.getProperty('subwikis').value.size() == 0)
+    {{warning}}$services.localization.render('flash.banner.subwikis.none'){{/warning}}
+
+  #end
   ## We don't have access to the form element to set the CSS class for the vertical form layout standard.
   #if("$!xcontext.action" == 'edit')
     #set ($discard = $xwiki.jsx.use('Flash.FlashSheet'))

--- a/application-flashmessages-ui/src/main/resources/Flash/FlashSheet.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/FlashSheet.xml
@@ -43,15 +43,6 @@
 #if ($doc.getObject('Flash.FlashClass'))
   #set($obj = $doc.getObject('Flash.FlashClass'))
   #set($discard = $doc.use('Flash.FlashClass'))
-  #if ($obj.getProperty('subwikis').value.size() == 0)
-    #if ($xcontext.action == 'edit' &amp;&amp; !$xwiki.exists($doc))
-      ## By default, newly created messages should be displayed on the current wiki.
-      #set ($discard = $obj.set('subwikis', $doc.getWiki()))
-    #else
-      {{warning}}$services.localization.render('flash.banner.subwikis.none'){{/warning}}
-
-    #end
-  #end
   ## We don't have access to the form element to set the CSS class for the vertical form layout standard.
   #if("$!xcontext.action" == 'edit')
     #set ($discard = $xwiki.jsx.use('Flash.FlashSheet'))

--- a/application-flashmessages-ui/src/main/resources/Flash/FlashTemplate.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/FlashTemplate.xml
@@ -255,6 +255,7 @@
     #end
     #set ($parameters = {
       'name': "${object.getxWikiClass().name}_${object.number}_${name}",
+      'id': "${object.getxWikiClass().name}_${object.number}_${name}",
       'value': $value,
       'multiple': 'multiple',
       'prefix': ' ',

--- a/application-flashmessages-ui/src/main/resources/Flash/FlashTemplate.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/FlashTemplate.xml
@@ -254,7 +254,7 @@
       #end
     #end
     #set ($parameters = {
-      'name': 'Flash.FlashClass_0_subwikis',
+      'name': "${object.getxWikiClass().name}_${object.number}_${name}",
       'value': $value,
       'multiple': 'multiple',
       'prefix': ' ',

--- a/application-flashmessages-ui/src/main/resources/Flash/FlashTemplate.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/FlashTemplate.xml
@@ -245,8 +245,7 @@
         <cache>0</cache>
         <customDisplay>{{velocity output="false"}}
 #template("pickers_macros.vm")
-{{/velocity}}
-{{velocity}}
+{{/velocity}}{{velocity}}
 #if ($type == 'edit')
     #set ($options = [{'name': $services.localization.render('flash.subwikis.empty'), 'value': ''}])
     #foreach ($subwiki in $services.wiki.getAll())

--- a/application-flashmessages-ui/src/main/resources/Flash/FlashTemplate.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/FlashTemplate.xml
@@ -241,20 +241,20 @@
         <values>daily|weekly|monthly|yearly</values>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </repeatInterval>
-      <subwikis>
+      <wikiScope>
         <cache>0</cache>
         <customDisplay/>
-        <defaultValue>current</defaultValue>
+        <defaultValue>currentWiki</defaultValue>
         <disabled>0</disabled>
         <displayType>select</displayType>
         <freeText/>
         <hint/>
         <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
-        <name>subwikis</name>
+        <name>wikiScope</name>
         <number>9</number>
         <picker>1</picker>
-        <prettyName>Subwikis</prettyName>
+        <prettyName/>
         <relationalStorage>0</relationalStorage>
         <separator> </separator>
         <separators>|, </separators>
@@ -263,9 +263,9 @@
         <unmodifiable>0</unmodifiable>
         <validationMessage/>
         <validationRegExp/>
-        <values>current|all</values>
+        <values>currentWiki|allWikis</values>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
-      </subwikis>
+      </wikiScope>
     </class>
     <property>
       <dateBegin/>
@@ -294,7 +294,7 @@
       <repeatInterval>daily</repeatInterval>
     </property>
     <property>
-      <subwikis/>
+      <wikiScope/>
     </property>
   </object>
 </xwikidoc>

--- a/application-flashmessages-ui/src/main/resources/Flash/FlashTemplate.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/FlashTemplate.xml
@@ -243,41 +243,14 @@
       </repeatInterval>
       <subwikis>
         <cache>0</cache>
-        <customDisplay>{{velocity output="false"}}
-#template("pickers_macros.vm")
-{{/velocity}}{{velocity}}
-#if ($type == 'edit')
-    #set ($options = [{'name': $services.localization.render('flash.subwikis.empty'), 'value': ''}])
-    #foreach ($subwiki in $services.wiki.getAll())
-      #if ($xcontext.hasAccessLevel('admin', "${subwiki.getId()}:XWiki.XWikiPreferences"))
-        #set ($discard = $options.add({ 'name': $subwiki.getPrettyName(), 'value': $subwiki.getId()}))
-      #end
-    #end
-    #set ($parameters = {
-      'name': "${object.getxWikiClass().name}_${object.number}_${name}",
-      'id': "${object.getxWikiClass().name}_${object.number}_${name}",
-      'value': $value,
-      'multiple': 'multiple',
-      'prefix': ' ',
-      'options': $options
-    })
-{{html}}
-    #staticSelectPicker($parameters)
-{{/html}}
-#elseif ($type == 'view')
-  #foreach ($subwiki in $value)
-    #set ($subwiki = $services.wiki.getById($subwiki))
-[[$services.rendering.escape($services.rendering.escape($subwiki.getPrettyName(), 'xwiki/2.1'), 'xwiki/2.1')&gt;&gt;$services.rendering.escape($subwiki.getMainPageReference(), 'xwiki/2.1')]] ##
-  #end
-#end
-{{/velocity}}</customDisplay>
-        <defaultValue/>
+        <customDisplay/>
+        <defaultValue>current</defaultValue>
         <disabled>0</disabled>
         <displayType>select</displayType>
         <freeText/>
-        <hint>Only wikis you have Admin rights on are listed.</hint>
+        <hint/>
         <largeStorage>0</largeStorage>
-        <multiSelect>1</multiSelect>
+        <multiSelect>0</multiSelect>
         <name>subwikis</name>
         <number>9</number>
         <picker>1</picker>
@@ -290,7 +263,7 @@
         <unmodifiable>0</unmodifiable>
         <validationMessage/>
         <validationRegExp/>
-        <values/>
+        <values>current|all</values>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </subwikis>
     </class>

--- a/application-flashmessages-ui/src/main/resources/Flash/FlashTemplate.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/FlashTemplate.xml
@@ -265,7 +265,7 @@
 {{/html}}
 #elseif ($type == 'view')
   #foreach ($subwiki in $value)
-    #set ($subwiki = $services.wiki.getById($subwiki))##
+    #set ($subwiki = $services.wiki.getById($subwiki))
 [[$services.rendering.escape($services.rendering.escape($subwiki.getPrettyName(), 'xwiki/2.1'), 'xwiki/2.1')&gt;&gt;$services.rendering.escape($subwiki.getMainPageReference(), 'xwiki/2.1')]] ##
   #end
 #end

--- a/application-flashmessages-ui/src/main/resources/Flash/FlashTemplate.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/FlashTemplate.xml
@@ -241,6 +241,58 @@
         <values>daily|weekly|monthly|yearly</values>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </repeatInterval>
+      <subwikis>
+        <cache>0</cache>
+        <customDisplay>{{velocity output="false"}}
+#template("pickers_macros.vm")
+{{/velocity}}
+{{velocity}}
+#if ($type == 'edit')
+    #set ($options = [{'name': $services.localization.render('flash.subwikis.empty'), 'value': ''}])
+    #foreach ($subwiki in $services.wiki.getAll())
+      #if ($xcontext.hasAccessLevel('admin', "${subwiki.getId()}:XWiki.XWikiPreferences"))
+        #set ($discard = $options.add({ 'name': $subwiki.getPrettyName(), 'value': $subwiki.getId()}))
+      #end
+    #end
+    #set ($parameters = {
+      'name': 'Flash.FlashClass_0_subwikis',
+      'value': $value,
+      'multiple': 'multiple',
+      'prefix': ' ',
+      'options': $options
+    })
+{{html}}
+    #staticSelectPicker($parameters)
+{{/html}}
+#elseif ($type == 'view')
+  #foreach ($subwiki in $value)
+    #set ($subwiki = $services.wiki.getById($subwiki))##
+[[$services.rendering.escape($services.rendering.escape($subwiki.getPrettyName(), 'xwiki/2.1'), 'xwiki/2.1')&gt;&gt;$services.rendering.escape($subwiki.getMainPageReference(), 'xwiki/2.1')]] ##
+  #end
+#end
+{{/velocity}}</customDisplay>
+        <defaultValue/>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText/>
+        <hint>Only wikis you have Admin rights on are listed.</hint>
+        <largeStorage>0</largeStorage>
+        <multiSelect>1</multiSelect>
+        <name>subwikis</name>
+        <number>9</number>
+        <picker>1</picker>
+        <prettyName>Subwikis</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <sort/>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <values/>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </subwikis>
     </class>
     <property>
       <dateBegin/>
@@ -267,6 +319,9 @@
     </property>
     <property>
       <repeatInterval>daily</repeatInterval>
+    </property>
+    <property>
+      <subwikis/>
     </property>
   </object>
 </xwikidoc>

--- a/application-flashmessages-ui/src/main/resources/Flash/Macros.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/Macros.xml
@@ -73,26 +73,5 @@
     &lt;/label&gt;
   : $!doc.display($propName, $obj)
 #end
-#macro(showFlashPopup)
-  {{html clean="false"}}
-  &lt;div class="modal fade" id="flashPopup" tabindex="-1" role="dialog" aria-hidden="true"&gt;
-    &lt;div class="modal-dialog"&gt;
-      &lt;div class="modal-content"&gt;
-        &lt;div class="modal-header"&gt;
-          &lt;button type="button" class="close" data-dismiss="modal"&gt;&amp;times;&lt;/button&gt;
-          &lt;h4 class="modal-title"&gt;&lt;/h4&gt;
-        &lt;/div&gt;
-        &lt;div class="modal-body"&gt;
-          &lt;div&gt;&lt;/div&gt;
-        &lt;/div&gt;
-        &lt;div class="modal-footer"&gt;
-          &lt;input type="button" class="btn btn-primary" disabled="disabled"
-            value="$escapetool.xml($services.localization.render('flash.flashmessages.confirm'))"/&gt;
-        &lt;/div&gt;
-      &lt;/div&gt;
-    &lt;/div&gt;
-  &lt;/div&gt;
-  {{/html}}
-#end
 {{/velocity}}</content>
 </xwikidoc>

--- a/application-flashmessages-ui/src/main/resources/Flash/Translations.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/Translations.xml
@@ -52,7 +52,7 @@ flash.livetable.dateEnd=End date
 flash.livetable.groups=Groups
 flash.livetable.message=Message
 flash.livetable.doc.date=Update date
-flash.livetable.subwikis=Subwikis
+flash.livetable.wikiScope=Message Scope
 flash.livetable._actions.edit=Edit
 flash.livetable._actions.delete=Delete
 flash.livetable._actions=Actions
@@ -78,9 +78,9 @@ Flash.FlashClass_repeatDays_saturday=Saturday
 Flash.FlashClass_repeatDays_sunday=Sunday
 Flash.FlashClass_message=Message
 Flash.FlashClass_groups=Groups
-Flash.FlashClass_subwikis=Subwikis
-Flash.FlashClass_subwikis_current=Current Wiki
-Flash.FlashClass_subwikis_all=All subwikis
+Flash.FlashClass_wikiScope=Message Scope
+Flash.FlashClass_wikiScope_currentWiki=Current Wiki
+Flash.FlashClass_wikiScope_allWikis=All Subwikis
 
 ## Sheet ##
 flash.repeat.summary=Repeat summary

--- a/application-flashmessages-ui/src/main/resources/Flash/Translations.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/Translations.xml
@@ -89,6 +89,7 @@ flash.repeat.summary.daily=days
 flash.repeat.summary.weekly=weeks
 flash.repeat.summary.monthly=months
 flash.repeat.summary.yearly=years
+flash.banner.subwikis.none=This flash message has no subwikis set, so it won't be displayed.
 
 ## Template Provider ##
 templateProvider.flashmessages.name=Flash Messages

--- a/application-flashmessages-ui/src/main/resources/Flash/Translations.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/Translations.xml
@@ -52,6 +52,7 @@ flash.livetable.dateEnd=End date
 flash.livetable.groups=Groups
 flash.livetable.message=Message
 flash.livetable.doc.date=Update date
+flash.livetable.subwikis=Subwikis
 flash.livetable._actions.edit=Edit
 flash.livetable._actions.delete=Delete
 flash.livetable._actions=Actions
@@ -78,7 +79,8 @@ Flash.FlashClass_repeatDays_sunday=Sunday
 Flash.FlashClass_message=Message
 Flash.FlashClass_groups=Groups
 Flash.FlashClass_subwikis=Subwikis
-flash.subwikis.empty=None
+Flash.FlashClass_subwikis_current=Current Wiki
+Flash.FlashClass_subwikis_all=All subwikis
 
 ## Sheet ##
 flash.repeat.summary=Repeat summary
@@ -89,7 +91,6 @@ flash.repeat.summary.daily=days
 flash.repeat.summary.weekly=weeks
 flash.repeat.summary.monthly=months
 flash.repeat.summary.yearly=years
-flash.banner.subwikis.none=This flash message has no subwikis set, so it won't be displayed.
 
 ## Template Provider ##
 templateProvider.flashmessages.name=Flash Messages

--- a/application-flashmessages-ui/src/main/resources/Flash/Translations.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/Translations.xml
@@ -77,6 +77,8 @@ Flash.FlashClass_repeatDays_saturday=Saturday
 Flash.FlashClass_repeatDays_sunday=Sunday
 Flash.FlashClass_message=Message
 Flash.FlashClass_groups=Groups
+Flash.FlashClass_subwikis=Subwikis
+flash.subwikis.empty=None
 
 ## Sheet ##
 flash.repeat.summary=Repeat summary

--- a/application-flashmessages-ui/src/main/resources/Flash/WebHomeSheet.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/WebHomeSheet.xml
@@ -60,10 +60,11 @@
 
   #set ($discard = $xwiki.ssfx.use('uicomponents/widgets/userpicker/userPicker.css', true))
   ##
-  #set($columns = ['doc.title', 'dateBegin', 'dateEnd', 'message', 'doc.date','groups', '_actions'])
+  #set($columns = ['doc.title', 'dateBegin', 'dateEnd', 'message', 'doc.date','groups', '_actions', 'subwikis'])
   #set($columnsProperties = {
     'doc.title': {'type': 'text', 'link': 'view', 'size': 10},
     'dateBegin': {'type': 'text', 'size': 10},
+    'subwikis': {'type': 'text', 'size': 10, 'html': true},
     'dateEnd': {'type': 'text', 'size': 10},
     'message': {'type': 'text', 'size': 10, 'sortable': false, 'html': true},
     'doc.date': {'type': 'text', 'link': 'view', 'size': 10},

--- a/application-flashmessages-ui/src/main/resources/Flash/WebHomeSheet.xml
+++ b/application-flashmessages-ui/src/main/resources/Flash/WebHomeSheet.xml
@@ -60,11 +60,11 @@
 
   #set ($discard = $xwiki.ssfx.use('uicomponents/widgets/userpicker/userPicker.css', true))
   ##
-  #set($columns = ['doc.title', 'dateBegin', 'dateEnd', 'message', 'doc.date','groups', '_actions', 'subwikis'])
+  #set($columns = ['doc.title', 'dateBegin', 'dateEnd', 'message', 'doc.date','groups', '_actions', 'wikiScope'])
   #set($columnsProperties = {
     'doc.title': {'type': 'text', 'link': 'view', 'size': 10},
     'dateBegin': {'type': 'text', 'size': 10},
-    'subwikis': {'type': 'text', 'size': 10, 'html': true},
+    'wikiScope': {'type': 'text', 'size': 10},
     'dateEnd': {'type': 'text', 'size': 10},
     'message': {'type': 'text', 'size': 10, 'sortable': false, 'html': true},
     'doc.date': {'type': 'text', 'link': 'view', 'size': 10},

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
   <description>Schedule and display flash announcements to one or multiple groups. Messages can be set as one off or recurring events. The app can be purchased individually or part of the XWiki Pro package. Try it free.</description>
    <properties>
     <licensing.version>1.27</licensing.version>
+     <xwikiprocommons.version>1.0.4</xwikiprocommons.version>
   </properties>
   <modules>
     <module>application-flashmessages-ui</module>


### PR DESCRIPTION
Added parameter for flashmessages to specify which subwiki to display the message in.

<img width="452" height="268" alt="image" src="https://github.com/user-attachments/assets/afe1ff28-a4ef-427b-b11c-df9bd32bce89" />

<img width="1085" height="628" alt="image" src="https://github.com/user-attachments/assets/5ad8e696-6643-46e0-aa52-ed7d7806ac70" />
